### PR TITLE
w-accordion: rotate expand icons of immediate item titles only

### DIFF
--- a/src/wave-ui/components/w-accordion.vue
+++ b/src/wave-ui/components/w-accordion.vue
@@ -148,8 +148,8 @@ export default {
     margin-right: $base-increment;
 
     .w-accordion--rotate-icon & {@include default-transition;}
-    .w-accordion--rotate-icon .w-accordion__item--expanded & {transform: rotate(-180deg);}
-    .w-accordion--rotate-icon.w-accordion--icon-right .w-accordion__item--expanded & {transform: rotate(180deg);}
+    .w-accordion--rotate-icon > .w-accordion__item--expanded > .w-accordion__item-title & {transform: rotate(-180deg);}
+    .w-accordion--rotate-icon.w-accordion--icon-right > .w-accordion__item--expanded > .w-accordion__item-title & {transform: rotate(180deg);}
 
     .w-icon:before {font-size: 1.1em;}
   }


### PR DESCRIPTION
Hi,

I was implementing a collapsible tree menu with accordions and noticed that nested expand/collapse icons were all synchronized with the root accordion item's expand/collapse icon.

What do you think about this fix?

-------------

Previously, accordions inside an accordion item would have all expand/collapse
icons set to expand when the root accordion item was expanded.
This was caused by the root accordion's CSS rules applying to the
sub-accordions.
To avoid this, the CSS rotate rules for the icon must select the immediate
item title's icon more explicitly.