### PR TITLE
Avoid console warning on empty w-select opening

### DIFF
--- a/src/wave-ui/components/w-select.vue
+++ b/src/wave-ui/components/w-select.vue
@@ -330,7 +330,7 @@ export default {
       setTimeout(() => {
         const itemIndex = this.inputValue.length ? this.inputValue[0].index : 0 // Real index starts at 0.
         // User visible index starts at 1.
-        this.$refs['w-list'].$el.querySelector(`#w-select-menu--${this._uid}_item-${itemIndex + 1}`).focus()
+        this.$refs['w-list'].$el.querySelector(`#w-select-menu--${this._uid}_item-${itemIndex + 1}`)?.focus()
       }, 100)
     },
 


### PR DESCRIPTION
Hi !
A tiny patch to avoid console warning when we open a w-select not hydrated yet.
Cheers,