### PR TITLE
[w-button] Fix loading slot

### DIFF
--- a/src/wave-ui/components/w-button/index.vue
+++ b/src/wave-ui/components/w-button/index.vue
@@ -6,6 +6,8 @@ component(v-if="tooltip" is="w-tooltip" v-bind="tooltipProps || {}")
   div(v-html="tooltip")
 button-partial(v-else v-bind="buttonProps")
   slot
+  template(#loading)
+    slot(name="loading")
 </template>
 
 <script>


### PR DESCRIPTION
Currently the documentation notes the `loading` slot [here](https://antoniandre.github.io/wave-ui/w-button#loading-spinner-and-custom-loader) for `w-button` but it doesn't work, even in the documentation.

Seems somewhere along the line we split the `w-button` across a couple files and the `index.vue` file.

This pull request adds a `loading` slot to the `w-button/index.vue` component and passes it along to the `w-button/button.vue` component.

There's one more potential consideration for a future pull request which is that in the `w-button/button.vue` component we wrap the loading slot with a `div.w-button__loader` which has very specific CSS in place to not resize the button and to center the spinner. However if you have some alternate text you'd like to display while it's disabled it will _not_ resize the button correctly because of this class.