### PR TITLE
[w-checkbox] Fix the cursor so it only affects the input and label

### DIFF
--- a/src/wave-ui/components/w-checkbox.vue
+++ b/src/wave-ui/components/w-checkbox.vue
@@ -149,12 +149,9 @@ $inactive-color: #666;
   vertical-align: middle;
   // Contain the hidden radio button, so browser doesn't pan to it when outside of the screen.
   position: relative;
-  cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 
   @include themeable;
-
-  &--disabled {cursor: not-allowed;}
 
   // The hidden real checkbox.
   input[type="checkbox"] {
@@ -173,8 +170,10 @@ $inactive-color: #666;
     flex: 0 0 auto; // Prevent stretching width or height.
     align-items: center;
     justify-content: center;
-    cursor: inherit;
+    cursor: pointer;
     z-index: 0;
+
+    .w-checkbox--disabled & {cursor: not-allowed;}
   }
 
   // The checkmark - visible when checked.
@@ -268,10 +267,13 @@ $inactive-color: #666;
   &__label {
     display: flex;
     align-items: center;
-    cursor: inherit;
+    cursor: pointer;
     user-select: none;
 
-    .w-checkbox--disabled & {opacity: 0.7;}
+    .w-checkbox--disabled & {
+      cursor: not-allowed;
+      opacity: 0.7;
+    }
   }
 }
 


### PR DESCRIPTION
When you wrap a `w-checkbox` or `w-checkboxes` in a `w-form` the additional `div` that gets inserted has `flex` and `grow` on it. Which is good!

However this expands the w-checkbox container element to grow. Currently the `cursor: pointer` is associated with the `w-checkbox` class. But when expanded we show a pointer cursor for the white space area to the side of the checkbox which isn't intractable.

[Here](https://codepen.io/dmilligan/pen/WNLvJmw?editors=1010) is a tiny codepen demonstrating the behavior. For the checkboxes in the `w-form` we get a pointer cursor all the way to the right of the screen because the div spans the whole width now. It's a little hard to describe in words. Here's an image with the red area highlighting where you get the `pointer` cursor when I believe it's not expected.

![image](https://github.com/antoniandre/wave-ui/assets/37845846/f9679539-b6a4-404a-a580-a0ac57e9f105)

This pull request moves the `cursor: pointer` to the `&__input` and `&__label` classes so that only the intractable parts of the w-checkbox change the cursor.

Assuming this gets accepted, this likely needs to be done for the `w-radio` as well.