### PR TITLE
[w-list] Allow de-selecting items by updating the model value

### DIFF
--- a/src/wave-ui/components/w-list.vue
+++ b/src/wave-ui/components/w-list.vue
@@ -347,11 +347,11 @@ export default {
       // Reset the selections when single selection allowed for w-select.
       if (!this.isMultipleSelect) this.listItems.forEach(item => (item._selected = false))
 
-      this.checkSelection(selection) // Create an array with the selected values.
-        .forEach(val => {
-          const foundItem = this.listItems.find(item => item._value === val)
-          if (foundItem) foundItem._selected = true
-        })
+      const selectedItems = this.checkSelection(selection) // Create an array with the selected values.
+      // Update which items are selected or not
+      this.listItems.forEach(item => {
+         item._selected = selectedItems.find(val => item._value === val) !== undefined
+      });
     }
   },
 


### PR DESCRIPTION
Currently on the `w-list` we have the method `applySelectionOnItems` which is called when the `modelValue` is changed from the `watch` method. Which can update the `_selected` property on the items to `true` but can not currently set it to false. This means that we can not modify the list of selected values to remove an item and have it de-select the value.

Here is a [Codepen](https://codepen.io/dmilligan/pen/poqNwYe?editors=1011) that demonstrates the issue. Note that when you click a button to select list item one we get the update, but when we remove the item we don't get the list updating correctly.

This pull request inverts the looping logic where it iterates over each `listItems` and checks to see if they exist in the array returned from `checkSelection` and updates the `_selected` value based upon whether it was found or not.