### PR TITLE
[w-table] Small fix to mobile table with pagination display.

### DIFF
--- a/src/wave-ui/components/w-table.vue
+++ b/src/wave-ui/components/w-table.vue
@@ -979,6 +979,7 @@ $tr-border-top: 1px;
 // Mobile layout.
 .w-table--mobile {
   display: flex;
+  flex-direction: column;
 
   thead {display: none;}
   tbody {

--- a/src/wave-ui/components/w-table.vue
+++ b/src/wave-ui/components/w-table.vue
@@ -1019,5 +1019,19 @@ $tr-border-top: 1px;
     td {display: table-cell;}
     td:before {display: none;}
   }
+
+  .w-table__footer {
+    .w-table__pagination-wrap {
+      .w-table__cell:before {display: none;}
+      .w-table__cell {
+        justify-content: center;
+
+        .w-table__pagination {
+          flex-direction: column;
+          gap: 0.5 * $base-increment;
+        }
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
Looks like mobile table with pagination is broken.

![image](https://github.com/antoniandre/wave-ui/assets/69513821/99ad85ac-1591-4704-9bd9-7e88024dc8e2)

With this commit it looks better and footer UI fits mobile.

![image](https://github.com/antoniandre/wave-ui/assets/69513821/b5ae9847-5b5a-4c0f-b3d6-7101ab5fac63)
![image](https://github.com/antoniandre/wave-ui/assets/69513821/059a5d62-286b-40b8-b45c-4793e17a3eb4)
