### PR TITLE
[w-autocomplete] Groups

### DIFF
--- a/src/documentation/views/ui-components/autocomplete/examples.vue
+++ b/src/documentation/views/ui-components/autocomplete/examples.vue
@@ -58,15 +58,16 @@ div
       app.use(WaveUI)
       app.mount('#app')
 
-  title-link(h2) Placeholder
+  title-link(h2) Groups / Multiselect
   example(content-class="py12" :blank-codepen="['js']")
-    w-autocomplete.mb12(:items="chemicalElement" placeholder="select an element")
+    w-autocomplete.mb12(:groups="animalGroups" :items="animals" multiple placeholder="select an animal")
     template(#pug).
-      w-autocomplete.mb12(:items="chemicalElement" placeholder="select an element")
+      w-autocomplete.mb12(:groups="animalGroups" :items="animals" multiple placeholder="select an animal")
     template(#html).
       &lt;w-autocomplete
-        :items="chemicalElement"
-        placeholder="select an element"
+        :groups="animalGroups"
+        :items="animals"
+        placeholder="select an animal"
         class="mb12"&gt;
       &lt;/w-autocomplete&gt;
     template(#js).
@@ -74,13 +75,19 @@ div
 
       const app = Vue.createApp({
         data: () => ({
-          chemicalElement: faker.definitions.science.chemicalElement.map(element => {
+          animals: [ 'dog', 'cat', 'bear' ].map(animal => faker.definitions.animal[animal].map(name => {
             return {
-              value: element.symbol,
-              label: element.name,
-              searchable: `${element.symbol}, ${element.name}, ${element.atomicNumber}`
+              value: name,
+              label: name,
+              searchable: name,
+              group: animal,
             }
-          })
+          })).flat(),
+          animalGroups: [
+            { group: 'dog', label: 'Dog' },
+            { group: 'cat', label: 'Cat' },
+            { group: 'bear', label: 'Bear' },
+          ]
         })
       })
 
@@ -97,9 +104,23 @@ export default {
       return {
         value: element.symbol,
         label: element.name,
-        searchable: `${element.symbol}, ${element.name}, ${element.atomicNumber}`
+        searchable: `${element.symbol}, ${element.name}, ${element.atomicNumber}`,
+        group: `row-${element.atomicNumber}`
       }
-    })
+    }),
+    animals: [ 'dog', 'cat', 'bear' ].map(animal => faker.definitions.animal[animal].map(name => {
+      return {
+        value: name,
+        label: name,
+        searchable: name,
+        group: animal,
+      }
+    })).flat(),
+    animalGroups: [
+      { group: 'dog', label: 'Dog' },
+      { group: 'cat', label: 'Cat' },
+      { group: 'bear', label: 'Bear' },
+    ]
   })
 }
 </script>

--- a/src/wave-ui/components/w-autocomplete.vue
+++ b/src/wave-ui/components/w-autocomplete.vue
@@ -20,7 +20,21 @@
       @mouseup="setEndOfMenuClick"
       @touchstart="menuIsBeingClicked = true"
       @touchend="setEndOfMenuClick")
+      template(v-if="groups" v-for="(group, g) in groups" :key="g")
+        slot(name="group" :group="group")
+          li.w-autocomplete__group.title5 {{ group[groupLabelKey] }}
+        template(v-for="(item, i) in filteredItems" :key="i")
+          li.w-autocomplete__group-item.ml2(
+            v-if="item.group === group[groupKey]"
+            @click.stop="selectItem(item), $emit('item-click', item)"
+            :class="{ highlighted: highlightedItem === item.uid }")
+            slot(
+              name="item"
+              :item="item"
+              :highlighted="highlightedItem === item.uid")
+              span(v-html="item[itemLabelKey]")
       li(
+        v-else
         v-for="(item, i) in filteredItems"
         :key="i"
         @click.stop="selectItem(item), $emit('item-click', item)"
@@ -45,6 +59,7 @@ export default {
 
   props: {
     items: { type: Array, required: true },
+    groups: { type: Array },
     modelValue: { type: [String, Number, Array] }, // String or Number if single selections, Array if multiple.
     placeholder: { type: String },
     openOnKeydown: { type: Boolean }, // By default the menu is always open for selection.
@@ -59,7 +74,12 @@ export default {
     itemLabelKey: { type: String, default: 'label' },
     // Contains the string to search keywords into for each item.
     // This can for instance be an aggregation of multiple fields (outside of Wave UI).
-    itemSearchableKey: { type: String, default: 'searchable' }
+    itemSearchableKey: { type: String, default: 'searchable' },
+    // Contains the key for the group on each item.
+    // Also is the key within groups for the group label.
+    groupKey: { type: String, default: 'group' },
+    // The label within the groups for the group name.
+    groupLabelKey: { type: String, default: 'label' }
   },
 
   // item-select is also from keyboard, 'item-click' may be useful for mouseenter mouseleave events.


### PR DESCRIPTION
One things that could be an interesting and useful feature for the autocomplete is the idea of grouping like elements together. Similar to how an `<optgroup>` functions inside a `<select>` grouping together similar `<option>`s.

@antoniandre I'm sure you'll have some ideas for how this could be done better or more in your style. I was just getting some thoughts out there and maybe some groundwork.

This is how this ends up looking:

![image](https://github.com/antoniandre/wave-ui/assets/37845846/c42fc48a-8f6c-4202-8105-bebeba77490d)

And while filtering with the groups:

![image](https://github.com/antoniandre/wave-ui/assets/37845846/d2ef71ad-07e2-4840-83b6-a502f99c3bf5)

### Shortcomings and thoughts about how I currently have it:
- I think that having to nest the `v-for` loops feels kind of bad and potentially has performance improvements if we made a computed value that split the `filteredItems` into groups so it could potentially be a faster render.
- Currently the group labels always display. Even if there are no filtered items within it. I think the computed route could potentially solve this in an easier way. See: 
![image](https://github.com/antoniandre/wave-ui/assets/37845846/7e06aabe-da5d-4083-ac9f-2fcbb9ba0e77)

I know that the `w-autocomplete` is a WIP and so is this PR. Let me know what you think and we can tweak stuff.
