### PR TITLE
[w-autocomplete] Multiple Selection Bug

### DIFF
--- a/src/wave-ui/components/w-autocomplete.vue
+++ b/src/wave-ui/components/w-autocomplete.vue
@@ -82,12 +82,6 @@ export default {
     },
 
     // Keep the autocomplete matching as fast as possible by caching optimized search strings.
-    // An array of optimized strings.
-    normalizedSelection () {
-      return this.selection.map(item => this.normalize(item?.searchable))
-    },
-
-    // Keep the autocomplete matching as fast as possible by caching optimized search strings.
     optimizedItemsForSearch () {
       return this.items.map((item, i) => ({
         ...item,
@@ -98,8 +92,7 @@ export default {
 
     filteredItems () {
       let items = this.optimizedItemsForSearch // Array of objects.
-      const selection = this.normalizedSelection.join(',') // Optimized string of coma separated words.
-      const isItemNotSelected = item => !selection.includes(item.searchable)
+      const isItemNotSelected = item => !this.selection.find(i => i.uid === item.uid)
 
       if (this.keywords) {
         items = items.filter(item => {


### PR DESCRIPTION
## The problem

[Here is a codepen](https://codepen.io/dmilligan/pen/qBwOpbP?editors=1010) demonstrating this issue.

If you select `Wave 2` or `Wave 3` from the autocomplete you'll notice that `Wave` has been removed from the list of options to use.

This happens because currently `filteredItems` removes currently selected items from the list of items by joining together a string of all the `searchable` fields of items and then doing an `includes` check.

Here is the codeblock where that logic currently lives:
```typescript
const selection = this.normalizedSelection.join(',') // Optimized string of coma separated words.
const isItemNotSelected = item => !selection.includes(item.searchable)
```

The problem is that because the `Wave` searchable string is technically a `substring` of both `Wave 2` and `Wave 3`'s searchable strings then it appears to have already been selected, when in reality is hasn't.

## The solution

Track selected items by UID instead. We already are associating a UID with each item and they're available for the selection. So we can avoid the string checks and joins altogether, at least for this selected check.

