### PR TITLE
[config] Color shades Css variable option

### DIFF
--- a/src/types/$waveui.ts
+++ b/src/types/$waveui.ts
@@ -66,6 +66,13 @@ export interface $waveui {
       colorShades: boolean,
 
       /**
+       * Generate CSS variables for color shades.
+       * NOTE: the `colorShades` must be enabled for this to work.
+       * @property {boolean} colorShadeCssVariables - Default: false
+       */
+      colorShadeCssVariables: boolean,
+
+      /**
        * Generate margin and padding utility classes for each breakpoint. E.g. `sm-ma2`
        * @property {boolean} breakpointSpaces - Default: false
        */

--- a/src/types/$waveui.ts
+++ b/src/types/$waveui.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { WaveColor } from './colors'
 import { WaveAlertProps } from './components/WAlert'
 
 export type WaveNotificationType = 'info' | 'success' | 'warning' | 'error';
@@ -10,10 +11,226 @@ export interface $waveui {
     md: boolean,
     lg: boolean,
     xl: boolean,
-    width: number|null
+    width: number|null,
   },
-  config: {},
-  colors: {}, // Object of pairs of color-name => color hex.
+  config: {
+    /**
+     * From version 3.0. Sets the Wave UI root on a custom node (expects a valid CSS selector)
+     * @property {string} on - Default: '#app', if not found body will be used
+     * @see https://antoniandre.github.io/wave-ui/options-presets-and-waveui
+     */
+    on: string,
+
+    /**
+     * Breakpoint settings
+     * @property breakpoints
+     * @see https://antoniandre.github.io/wave-ui/breakpoints#default-breakpoints
+     * @see https://antoniandre.github.io/wave-ui/options-presets-and-waveui
+     */
+    breakpoints: {
+      /**
+       * @property {number} xs - Default: 600
+       */
+      xs: number,
+      /**
+       * @property {number} sm - Default: 900
+       */
+      sm: number,
+      /**
+       * @property {number} md - Default: 1200
+       */
+      md: number,
+      /**
+       * @property {number} lg - Default: 1700
+       */
+      lg: number,
+      /**
+       * Xl only needs a greater value than lg but starts from lg and goes to infinity.
+       * @property {number} xl - Default: 9999
+       */
+      xl: number,
+    },
+
+    /**
+     * Css settings
+     * @property css
+     * @see https://antoniandre.github.io/wave-ui/colors
+     * @see https://antoniandre.github.io/wave-ui/options-presets-and-waveui
+     */
+    css: {
+      /**
+       * Generate shades for custom colors and status colors.
+       * NOTE: the color palette shades are always generated separately from SCSS.
+       * @property {boolean} colorShades - Default: true
+       */
+      colorShades: boolean,
+
+      /**
+       * Generate margin and padding utility classes for each breakpoint. E.g. `sm-ma2`
+       * @property {boolean} breakpointSpaces - Default: false
+       */
+      breakpointSpaces: boolean,
+
+      /**
+       * Generate helper classes for each breakpoint. E.g. `sm-text-left` `sm-hide`
+       * @property {boolean} breakpointLayoutClasses - Default: true
+       * @see https://antoniandre.github.io/wave-ui/breakpoints#breakpoint-specific-layout-classes
+       */
+      breakpointLayoutClasses: boolean,
+
+      /**
+       * How many columns the flexbox based grid will use
+       * @property {number} grid - Default: 12
+       * @see https://antoniandre.github.io/wave-ui/layout--grid-system
+       */
+      grid: number,
+    },
+
+    /**
+     * Color/Theme settings
+     * @property colors
+     * @see https://antoniandre.github.io/wave-ui/colors
+     * @see https://antoniandre.github.io/wave-ui/colors#defining-your-own-css-colors-in-the-wave-ui-configuration
+     */
+    colors: {
+      /**
+       * The light theme default colors
+       * @property light
+       */
+      light: {
+        /**
+         * @property {string} primary - Default: '#234781'
+         */
+        primary: string,
+
+        /**
+         * @property {string} secondary - Default: '#d3ebff'
+         */
+        secondary: string,
+
+        /**
+         * @property {string} info - Default: '#3d9ff5'
+         */
+        info: string,
+
+        /**
+         * @property {string} warning - Default: '#ff8800'
+         */
+        warning: string,
+
+        /**
+         * @property {string} success - Default: '#54b946'
+         */
+        success: string,
+
+        /**
+         * @property {string} error - Default: '#f65555'
+         */
+        error: string,
+
+        /**
+         * Here any additional colors can be defined by the user.
+         * @property {string} {string}
+         * @see https://antoniandre.github.io/wave-ui/colors#defining-your-own-css-colors-in-the-wave-ui-configuration
+         */
+        [key: string]: string
+      },
+
+      /**
+       * The dark theme default colors
+       * @property dark
+       */
+      dark: {
+        /**
+         * @property {string} primary - Default: '#89b6d2'
+         */
+        primary: string,
+
+        /**
+         * @property {string} secondary - Default: '#375b6a'
+         */
+        secondary: string,
+
+        /**
+         * @property {string} info - Default: '#3d9ff5'
+         */
+        info: string,
+
+        /**
+         * @property {string} warning - Default: '#ff8800'
+         */
+        warning: string,
+
+        /**
+         * @property {string} success - Default: '#54b946'
+         */
+        success: string,
+
+        /**
+         * @property {string} error - Default: '#f65555'
+         */
+        error: string,
+
+        /**
+         * Here any additional colors can be defined by the user.
+         * @property {string} {string}
+         * @see https://antoniandre.github.io/wave-ui/colors#defining-your-own-css-colors-in-the-wave-ui-configuration
+         */
+        [key: string]: string
+      },
+    },
+
+    /**
+     * The initial theme to use
+     * To switch theme while running, call the $waveui.switchTheme('light'|'dark') method.
+     * @property {string} theme - Default: 'light'
+     * @see https://antoniandre.github.io/wave-ui/options-presets-and-waveui
+     */
+    theme: 'light' | 'dark' | 'auto',
+
+    /**
+     * Not sure what this does.
+     * @property {array} icons - Default: '[]'
+     * @see https://antoniandre.github.io/wave-ui/w-icon
+     */
+    icons: [],
+
+    /**
+     * Whether or not to use icon ligatures
+     * @property {boolean} iconsLigature - Default: 'false'
+     * @see https://antoniandre.github.io/wave-ui/w-icon
+     */
+    iconsLigature: boolean,
+
+    /**
+     * Notification manager settings
+     * @property align
+     * @see https://antoniandre.github.io/wave-ui/w-notification
+     */
+    notificationManager: {
+      /**
+       * Here any additional colors can be defined by the user.
+       * @property {string} align - Default: 'right'
+       * @see https://antoniandre.github.io/wave-ui/w-notification#align-to-the-left-or-right
+       */
+      align: 'right' | 'left',
+
+      /**
+       * Here any additional colors can be defined by the user.
+       * @property {string|false} transition - Default: 'default'
+       * @see https://antoniandre.github.io/wave-ui/w-notification#different-transitions
+       */
+      transition: false | 'default' | 'bounce' | 'scale' | 'twist' | 'fade' | 'slide-fade-left' | 'slide-fade-right' | 'slide-fade-up' | 'slide-fade-down',
+    },
+
+    /**
+     * Component presets
+     * @property presets
+     * @see https://antoniandre.github.io/wave-ui/options-presets-and-waveui
+     */
+    presets: Record<string, Record<string, string | number | boolean>>,
+  },
+  colors: Record<WaveColor | string, string>, // Object of pairs of color-name => color hex.
   preferredTheme: null, // The user OS preferred theme (light or dark).
   theme: null, // The current theme (light or dark).
   _notificationManager: null,

--- a/src/wave-ui/core.js
+++ b/src/wave-ui/core.js
@@ -85,7 +85,7 @@ export default class WaveUI {
       document.documentElement.setAttribute('data-theme', theme)
       document.head.querySelector('#wave-ui-colors')?.remove?.()
       const themeColors = this.config.colors[this.theme]
-      injectColorsCSSInDOM(themeColors)
+      injectColorsCSSInDOM(themeColors, this.config.css.colorShadeCssVariables)
       this.colors = flattenColors(themeColors, colorPalette)
     }
   }

--- a/src/wave-ui/utils/config.js
+++ b/src/wave-ui/utils/config.js
@@ -14,6 +14,10 @@ const config = reactive({
     // Note: the color palette shades are always generated separately from SCSS.
     colorShades: true,
 
+    // Generate CSS variables for color shades.
+    // Note: colorShades must be enabled for this to work.
+    colorShadeCssVariables: false,
+
     // Generate palette colors and palette color shades.
     // Can't have this option: color palette is generated via SCSS in colors.scss.
     // colorPalette: true,

--- a/src/wave-ui/utils/dynamic-css.js
+++ b/src/wave-ui/utils/dynamic-css.js
@@ -13,7 +13,7 @@ let currentBreakpoint = null
 // :root {[color1-variable], [color2-variable]}
 // .color1--bg {background-color: [color1-variable]}
 // .color1 {color: [color1-variable]}
-const generateColors = themeColors => {
+const generateColors = (themeColors, generateShadeCssVariables) => {
   let styles = ''
   const cssVariables = {}
 
@@ -42,6 +42,9 @@ const generateColors = themeColors => {
   // That only makes sense when there are 2 colors on the same element: e.g. `span.primary.error`.
   const allColors = { ...colors, info, warning, success, error }
   for (const colorName in allColors) cssVariables[colorName] = allColors[colorName]
+  if (generateShadeCssVariables) {
+    for (const colorName in shades) cssVariables[colorName] = shades[colorName]
+  }
   let cssVariablesString = ''
   Object.entries(cssVariables).forEach(([colorName, colorHex]) => {
     cssVariablesString += `--w-${colorName}-color: ${colorHex};`
@@ -269,12 +272,12 @@ export const injectCSSInDOM = $waveui => {
   window.addEventListener('resize', () => getBreakpoint($waveui))
 }
 
-export const injectColorsCSSInDOM = themeColors => {
+export const injectColorsCSSInDOM = (themeColors, generateShadeCssVariables) => {
   // Inject global dynamic CSS classes in document head.
   if (!document.getElementById('wave-ui-colors')) {
     const css = document.createElement('style')
     css.id = 'wave-ui-colors'
-    css.innerHTML = generateColors(themeColors)
+    css.innerHTML = generateColors(themeColors, generateShadeCssVariables)
 
     const firstStyle = document.head.querySelectorAll('style,link[rel="stylesheet"]')[0]
     if (firstStyle) firstStyle.before(css)


### PR DESCRIPTION
This PR adds a new config `css.colorShadeCssVariables` which slightly modifies how the `generateColors` method works. It allows for that method to also generate CSS variables for all the shades as well giving easier access to use them when you have to have a component or HTML element that isn't a Wave component supporting the `bg-color` or `color` props.