### PR TITLE
[w-select] Add checklist property

### DIFF
--- a/src/documentation/views/ui-components/select/api.vue
+++ b/src/documentation/views/ui-components/select/api.vue
@@ -18,6 +18,7 @@ const propsDescs = {
   items: 'Expecting an array of objects. Each object being a select list item, it should include at least a <code>label</code> attribute.',
   modelValue: '<strong class="error"><code>value</code> in Vue 2.</strong><br>The current selection of the select field.<br>Gets updated on selection change.',
   multiple: 'Allows multiple selections. When set to <code>true</code>, the list of choices will stay open after selecting an item.',
+  checklist: 'Exposes the <code>w-list</code> property <code>checklist</code>. See the <a href="w-list#checklist-prop">w-list checklist property</a> for more information.<br>When enabled a checkbox will display next to each list item, this can be particularly useful when the <code>multiple</code> property is set to <code>true</code>',
   placeholder: 'Provide a placeholder for the select field. If a label is positioned inside, it will be moved above the field so it doesn\'t overlap.',
   label: 'Sets a visible label for the select field.',
   labelPosition: 'Sets the position of the label to one of the following positions: \'left\', \'right\', \'inside\'.',

--- a/src/types/components/WSelect.ts
+++ b/src/types/components/WSelect.ts
@@ -44,6 +44,15 @@ export interface WaveSelectProps {
   multiple?: boolean
 
   /**
+   * Exposes the w-list property `checklist` to the select list items.
+   * When enabled a checkbox will display next to each list item, this can
+   * be particularly useful when the `multiple` prop is set to `true`.
+   * @property {boolean} checklist
+   * @see https://antoniandre.github.io/wave-ui/w-select
+   */
+  checklist?: boolean
+
+  /**
    * Provide a placeholder for the select field. If a label is positioned inside, it will be moved above the field so it doesn't overlap.
    * @property {string} placeholder
    * @see https://antoniandre.github.io/wave-ui/w-select

--- a/src/wave-ui/components/w-select.vue
+++ b/src/wave-ui/components/w-select.vue
@@ -75,6 +75,7 @@ component(
       @keydown:escape="showMenu && (showMenu = false) /* Will call closeMenu() from w-menu(@close). */"
       :items="selectItems"
       :multiple="multiple"
+      :checklist="checklist"
       arrows-navigation
       return-object
       :add-ids="`w-select-menu--${_.uid}`"
@@ -116,6 +117,7 @@ export default {
     items: { type: Array, required: true },
     modelValue: {}, // v-model on selected item if any.
     multiple: { type: Boolean },
+    checklist: { type: Boolean }, // the prop from w-list for checkboxes
     placeholder: { type: String },
     label: { type: String },
     labelPosition: { type: String, default: 'inside' },


### PR DESCRIPTION
This PR adds the `checklist` property to the `w-select` component. Which is just a small pass through property to the underlying `w-list`.

Having this property can make using the `multiple` prop more visually appealing in some cases.

There could be an argument made that whenever `multiple` is enabled that `checklist` should be as well. However I was keeping stuff separated so that people have options to do things how they'd like.