### PR TITLE
[css] Add the 'css-scope' to all the component CSS styles

### DIFF
--- a/src/wave-ui/components/w-accordion.vue
+++ b/src/wave-ui/components/w-accordion.vue
@@ -169,63 +169,65 @@ export default {
 </script>
 
 <style lang="scss">
-.w-accordion {
-  z-index: 1;
+#{$css-scope} {
+  .w-accordion {
+    z-index: 1;
 
-  @include themeable;
+    @include themeable;
 
-  &--shadow {box-shadow: $box-shadow;}
+    &--shadow {box-shadow: $box-shadow;}
 
-  &__item {position: relative;}
+    &__item {position: relative;}
 
-  button.w-accordion__expand-icon {color: rgba(var(--w-base-color-rgb), 0.4);}
-  &__expand-icon {
-    margin-right: $base-increment;
+    button.w-accordion__expand-icon {color: rgba(var(--w-base-color-rgb), 0.4);}
+    &__expand-icon {
+      margin-right: $base-increment;
 
-    .w-accordion--rotate-icon & {@include default-transition;}
-    &--rotate90 {transform: rotate(-90deg);}
-    &--expanded {transform: rotate(-180deg);}
-    &--expanded.w-accordion__expand-icon--rotate90 {transform: rotate(0deg);}
+      .w-accordion--rotate-icon & {@include default-transition;}
+      &--rotate90 {transform: rotate(-90deg);}
+      &--expanded {transform: rotate(-180deg);}
+      &--expanded.w-accordion__expand-icon--rotate90 {transform: rotate(0deg);}
 
-    .w-icon:before {font-size: 1.1em;}
-  }
+      .w-icon:before {font-size: 1.1em;}
+    }
 
-  &__item-title {
-    position: relative;
-    display: flex;
-    align-items: center;
-    font-size: round(1.2 * $base-font-size);
-    padding: 1 * $base-increment;
-    user-select: none;
-    cursor: pointer;
-    border-top: $border;
-    -webkit-tap-highlight-color: transparent;
-
-    .w-accordion__item--disabled & {
-      cursor: not-allowed;
-      opacity: 0.6;
+    &__item-title {
+      position: relative;
+      display: flex;
+      align-items: center;
+      font-size: round(1.2 * $base-font-size);
+      padding: 1 * $base-increment;
+      user-select: none;
+      cursor: pointer;
+      border-top: $border;
       -webkit-tap-highlight-color: transparent;
+
+      .w-accordion__item--disabled & {
+        cursor: not-allowed;
+        opacity: 0.6;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .w-accordion--no-icon &, .w-accordion--icon-right & {padding-left: 3 * $base-increment;}
+
+      .w-accordion__item:first-child & {border-top-color: transparent;}
+
+      &:before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: currentColor;
+        opacity: 0;
+        transition: $fast-transition-duration;
+      }
+
+      &:focus:before, &:hover:before {opacity: 0.03;}
+      &:active:before {opacity: 0.05;}
+      .w-accordion__item--disabled &:before {display: none;}
     }
-    .w-accordion--no-icon &, .w-accordion--icon-right & {padding-left: 3 * $base-increment;}
 
-    .w-accordion__item:first-child & {border-top-color: transparent;}
-
-    &:before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-color: currentColor;
-      opacity: 0;
-      transition: $fast-transition-duration;
+    &__item-content {
+      padding: (2 * $base-increment) (3 * $base-increment);
     }
-
-    &:focus:before, &:hover:before {opacity: 0.03;}
-    &:active:before {opacity: 0.05;}
-    .w-accordion__item--disabled &:before {display: none;}
-  }
-
-  &__item-content {
-    padding: (2 * $base-increment) (3 * $base-increment);
   }
 }
 </style>

--- a/src/wave-ui/components/w-alert.vue
+++ b/src/wave-ui/components/w-alert.vue
@@ -131,123 +131,125 @@ export default {
 </script>
 
 <style lang="scss">
-.w-alert {
-  position: relative;
-  margin-top: 4 * $base-increment;
-  margin-bottom: 4 * $base-increment;
-  padding: 2 * $base-increment;
-  font-size: round(1.1 * $base-font-size);
-  font-weight: 700;
-  border-radius: $border-radius;
-  border: 1px solid currentColor;
+#{$css-scope} {
+  .w-alert {
+    position: relative;
+    margin-top: 4 * $base-increment;
+    margin-bottom: 4 * $base-increment;
+    padding: 2 * $base-increment;
+    font-size: round(1.1 * $base-font-size);
+    font-weight: 700;
+    border-radius: $border-radius;
+    border: 1px solid currentColor;
 
-  @include themeable;
+    @include themeable;
 
-  &--has-icon {
-    display: flex;
-    align-items: center;
-  }
+    &--has-icon {
+      display: flex;
+      align-items: center;
+    }
 
-  &--outline {border-color: currentColor;}
-  &--tile {border-radius: 0;}
-  &--round {
-    border-radius: 99em;
-    padding-left: 3 * $base-increment;
-    padding-right: 3 * $base-increment;
-  }
-  &--shadow {box-shadow: $box-shadow;}
-  &--no-border, &--one-border, &--plain {border: transparent;}
+    &--outline {border-color: currentColor;}
+    &--tile {border-radius: 0;}
+    &--round {
+      border-radius: 99em;
+      padding-left: 3 * $base-increment;
+      padding-right: 3 * $base-increment;
+    }
+    &--shadow {box-shadow: $box-shadow;}
+    &--no-border, &--one-border, &--plain {border: transparent;}
 
-  // Before for the border, after for the background color.
-  // ------------------------------------------------------
-  &:before, &:after {
-    position: absolute;
-    inset: 0;
-    background-color: currentColor;
-    pointer-events: none;
-  }
+    // Before for the border, after for the background color.
+    // ------------------------------------------------------
+    &:before, &:after {
+      position: absolute;
+      inset: 0;
+      background-color: currentColor;
+      pointer-events: none;
+    }
 
-  // Single side border.
-  // ------------------------------------------------------
-  &--border-left {padding-left: 3 * $base-increment;}
-  &--border-right {padding-right: 3 * $base-increment;}
-  &--border-top {padding-top: 3 * $base-increment;}
-  &--border-bottom {padding-bottom: 3 * $base-increment;}
+    // Single side border.
+    // ------------------------------------------------------
+    &--border-left {padding-left: 3 * $base-increment;}
+    &--border-right {padding-right: 3 * $base-increment;}
+    &--border-top {padding-top: 3 * $base-increment;}
+    &--border-bottom {padding-bottom: 3 * $base-increment;}
 
-  &--one-border:before {content: '';opacity: 0.3;}
-  &--border-left:before {
-    right: auto;
-    width: $base-increment;
-    border-top-left-radius: inherit;
-    border-bottom-left-radius: inherit;
-  }
-  &--border-right:before {
-    left: auto;
-    width: $base-increment;
-    border-top-right-radius: inherit;
-    border-bottom-right-radius: inherit;
-  }
-  &--border-top:before {
-    bottom: auto;
-    height: $base-increment;
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
-  }
-  &--border-bottom:before {
-    top: auto;
-    height: $base-increment;
-    border-bottom-left-radius: inherit;
-    border-bottom-right-radius: inherit;
-  }
-  &--one-border.w-alert--icon-outside:before {
-    content: '';
-    opacity: 0.7;
-    width: 3px;
-  }
+    &--one-border:before {content: '';opacity: 0.3;}
+    &--border-left:before {
+      right: auto;
+      width: $base-increment;
+      border-top-left-radius: inherit;
+      border-bottom-left-radius: inherit;
+    }
+    &--border-right:before {
+      left: auto;
+      width: $base-increment;
+      border-top-right-radius: inherit;
+      border-bottom-right-radius: inherit;
+    }
+    &--border-top:before {
+      bottom: auto;
+      height: $base-increment;
+      border-top-left-radius: inherit;
+      border-top-right-radius: inherit;
+    }
+    &--border-bottom:before {
+      top: auto;
+      height: $base-increment;
+      border-bottom-left-radius: inherit;
+      border-bottom-right-radius: inherit;
+    }
+    &--one-border.w-alert--icon-outside:before {
+      content: '';
+      opacity: 0.7;
+      width: 3px;
+    }
 
-  &:after {opacity: 0.12;content: '';border-radius: inherit;}
-  &--outline:after {display: none;}
-  &--bg:after {background-color: #fff;opacity: 0.1;}
+    &:after {opacity: 0.12;content: '';border-radius: inherit;}
+    &--outline:after {display: none;}
+    &--bg:after {background-color: #fff;opacity: 0.1;}
 
-  // Left icon and dismiss button.
-  // ------------------------------------------------------
-  &__dismiss.w-button {
-    align-self: flex-start;
-    margin-left: 2 * $base-increment;
-    margin-top: round(-0.5 * $base-increment);
-    margin-right: round(-0.5 * $base-increment);
+    // Left icon and dismiss button.
+    // ------------------------------------------------------
+    &__dismiss.w-button {
+      align-self: flex-start;
+      margin-left: 2 * $base-increment;
+      margin-top: round(-0.5 * $base-increment);
+      margin-right: round(-0.5 * $base-increment);
+    }
+
+    & &__icon {
+      opacity: 0.9;
+      align-self: flex-start;
+      margin-right: 2 * $base-increment;
+      font-size: 1.3em;
+    }
+    &--has-icon &__content {flex-grow: 1;align-self: flex-start;}
+    @-moz-document url-prefix() {
+      &--has-icon &__content {margin-top: 0.18em;}
+    }
+
+    &--icon-outside &__icon {
+      position: absolute;
+      opacity: 1;
+      left: 1px;
+      z-index: 1;
+      transform: translateX(-50%);
+      border: 1px solid rgba(var(--w-base-bg-color-rgb), 0.7);
+      background-color: $base-bg-color;
+    }
+    &--icon-outside &__icon:before {transform: scale(1.05);}
+
+    &--icon-outside &__content {padding-left: 3 * $base-increment;}
+
+    // Sizes.
+    // ------------------------------------------------------
+    &.size--xs {padding-top: $base-increment;padding-bottom: $base-increment;}
+    &.size--sm {padding-top: $base-increment;padding-bottom: $base-increment;}
+    &.size--md {padding-top: round(2 * $base-increment);padding-bottom: round(2 * $base-increment);}
+    &.size--lg {padding-top: round(3 * $base-increment);padding-bottom: round(2.5 * $base-increment);}
+    &.size--xl {padding-top: round(3 * $base-increment);padding-bottom: round(3 * $base-increment);}
   }
-
-  & &__icon {
-    opacity: 0.9;
-    align-self: flex-start;
-    margin-right: 2 * $base-increment;
-    font-size: 1.3em;
-  }
-  &--has-icon &__content {flex-grow: 1;align-self: flex-start;}
-  @-moz-document url-prefix() {
-    &--has-icon &__content {margin-top: 0.18em;}
-  }
-
-  &--icon-outside &__icon {
-    position: absolute;
-    opacity: 1;
-    left: 1px;
-    z-index: 1;
-    transform: translateX(-50%);
-    border: 1px solid rgba(var(--w-base-bg-color-rgb), 0.7);
-    background-color: $base-bg-color;
-  }
-  &--icon-outside &__icon:before {transform: scale(1.05);}
-
-  &--icon-outside &__content {padding-left: 3 * $base-increment;}
-
-  // Sizes.
-  // ------------------------------------------------------
-  &.size--xs {padding-top: $base-increment;padding-bottom: $base-increment;}
-  &.size--sm {padding-top: $base-increment;padding-bottom: $base-increment;}
-  &.size--md {padding-top: round(2 * $base-increment);padding-bottom: round(2 * $base-increment);}
-  &.size--lg {padding-top: round(3 * $base-increment);padding-bottom: round(2.5 * $base-increment);}
-  &.size--xl {padding-top: round(3 * $base-increment);padding-bottom: round(3 * $base-increment);}
 }
 </style>

--- a/src/wave-ui/components/w-autocomplete.vue
+++ b/src/wave-ui/components/w-autocomplete.vue
@@ -315,90 +315,92 @@ export default {
 </script>
 
 <style lang="scss">
-.w-autocomplete {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  position: relative;
-  border-radius: $border-radius;
-  border: $border;
-  padding: 2px 4px;
-  user-select: none;
-
-  &--open {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  &__selection {
+#{$css-scope} {
+  .w-autocomplete {
     display: flex;
-    align-items: center;
-    background: rgba(var(--w-contrast-bg-color-rgb), 0.035);
-    border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.05);
+    flex-wrap: wrap;
+    gap: 4px;
+    position: relative;
     border-radius: $border-radius;
-    padding: 0 2px 0 4px;
-    flex-shrink: 0;
+    border: $border;
+    padding: 2px 4px;
+    user-select: none;
 
-    span {margin-top: -1px;line-height: 1;}
-    .w-button .w-icon:before {font-size: 0.8em;line-height: 0;}
-  }
+    &--open {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
 
-  &__input {
-    min-width: 0;
-    flex: 1 1 0;
-    color: inherit;
-    border: none;
-    background-color: transparent;
-    line-height: 18px;
-  }
+    &__selection {
+      display: flex;
+      align-items: center;
+      background: rgba(var(--w-contrast-bg-color-rgb), 0.035);
+      border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.05);
+      border-radius: $border-radius;
+      padding: 0 2px 0 4px;
+      flex-shrink: 0;
 
-  &__placeholder {
-    color: rgba(var(--w-base-color-rgb), 0.5);
-    pointer-events: none;
-    line-height: 18px;
-  }
+      span {margin-top: -1px;line-height: 1;}
+      .w-button .w-icon:before {font-size: 0.8em;line-height: 0;}
+    }
 
-  &__menu {
-    position: absolute;
-    inset: 100% -1px auto;
-    max-height: clamp(20px, 400px, 80vh);
-    margin-top: -1px;
-    margin-left: 0;
-    background-color: $base-bg-color;
-    border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.2);
-    border-top: none;
-    border-bottom-left-radius: $border-radius;
-    border-bottom-right-radius: $border-radius;
-    overflow: auto;
-    z-index: 10;
+    &__input {
+      min-width: 0;
+      flex: 1 1 0;
+      color: inherit;
+      border: none;
+      background-color: transparent;
+      line-height: 18px;
+    }
 
-    li {
-      position: relative;
-      list-style-type: none;
-      margin: 0;
-      padding: 4px 8px;
+    &__placeholder {
+      color: rgba(var(--w-base-color-rgb), 0.5);
+      pointer-events: none;
+      line-height: 18px;
+    }
 
-      &:hover {background-color: rgba($primary, 0.1);}
+    &__menu {
+      position: absolute;
+      inset: 100% -1px auto;
+      max-height: clamp(20px, 400px, 80vh);
+      margin-top: -1px;
+      margin-left: 0;
+      background-color: $base-bg-color;
+      border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.2);
+      border-top: none;
+      border-bottom-left-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
+      overflow: auto;
+      z-index: 10;
 
-      &:before, &:after {
-        content: '';
-        position: absolute;
-        inset: 0;
-      }
+      li {
+        position: relative;
+        list-style-type: none;
+        margin: 0;
+        padding: 4px 8px;
 
-      &.highlighted:before {
-        border-left: 2px solid transparent;
-        border-left-color: $primary;
-        opacity: 0.3;
-      }
+        &:hover {background-color: rgba($primary, 0.1);}
 
-      &.highlighted:after {
-        background-color: $primary;
-        opacity: 0.1;
+        &:before, &:after {
+          content: '';
+          position: absolute;
+          inset: 0;
+        }
+
+        &.highlighted:before {
+          border-left: 2px solid transparent;
+          border-left-color: $primary;
+          opacity: 0.3;
+        }
+
+        &.highlighted:after {
+          background-color: $primary;
+          opacity: 0.1;
+        }
       }
     }
   }
-}
 
-li.w-autocomplete__no-match--default:hover {background-color: transparent;}
+  li.w-autocomplete__no-match--default:hover {background-color: transparent;}
+}
 </style>

--- a/src/wave-ui/components/w-badge.vue
+++ b/src/wave-ui/components/w-badge.vue
@@ -92,108 +92,110 @@ export default {
 </script>
 
 <style lang="scss">
-.w-badge-wrap {
-  position: relative;
-  display: inline-flex;
-}
-
-.w-badge {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  user-select: none;
-  border-radius: 99em;
-  // Always get an even number for better text vertical align.
-  height: round(1.1 * divide($base-font-size, 2)) * 2;
-  line-height: round(1.1 * divide($base-font-size, 2)) * 2;
-  min-width: round(1.1 * divide($base-font-size, 2)) * 2;
-  z-index: 1;
-  padding: 0 $base-increment;
-
-  @include themeable;
-
-  &--inline {position: static;}
-
-  &--round {
-    aspect-ratio: 1;
-    min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-    padding: 0;
+#{$css-scope} {
+  .w-badge-wrap {
+    position: relative;
+    display: inline-flex;
   }
 
-  // Sizes.
-  &.size--xs {
-    // Always get an even number for better text vertical alignment.
-    $height: round(divide($base-font-size, 2)) * 2;
-    font-size: round(0.67 * divide($base-font-size, 2)) * 2;
-    height: $height;
-    line-height: $height;
-    min-width: $height;
+  .w-badge {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    border-radius: 99em;
+    // Always get an even number for better text vertical align.
+    height: round(1.1 * divide($base-font-size, 2)) * 2;
+    line-height: round(1.1 * divide($base-font-size, 2)) * 2;
+    min-width: round(1.1 * divide($base-font-size, 2)) * 2;
+    z-index: 1;
+    padding: 0 $base-increment;
 
-    &--round {width: $height;padding: 0 round(divide($height, 2));}
-  }
-  &.size--sm {
-    $height: round(1.1 * divide($base-font-size, 2)) * 2;
-    font-size: round(0.75 * divide($base-font-size, 2)) * 2;
-    height: $height;
-    line-height: $height;
-    min-width: $height;
-  }
-  &.size--md {
-    $height: round(1.3 * divide($base-font-size, 2)) * 2;
-    font-size: round(0.9 * divide($base-font-size, 2)) * 2;
-    height: $height;
-    line-height: $height;
-    min-width: $height;
-  }
-  &.size--lg {
-    $height: round(1.5 * divide($base-font-size, 2)) * 2;
-    font-size: round(1.05 * divide($base-font-size, 2)) * 2;
-    height: $height;
-    line-height: $height;
-    min-width: $height;
-  }
-  &.size--xl {
-    $height: round(1.8 * divide($base-font-size, 2)) * 2;
-    font-size: round(1.2 * divide($base-font-size, 2)) * 2;
-    height: $height;
-    line-height: $height;
-    min-width: $height;
-  }
+    @include themeable;
 
-  // Position.
-  &--top {top: 0;}
-  &--bottom {bottom: 0;}
-  &--left {right: 100%;}
-  &--right {left: 100%;}
-  &--overlap {
-    &.w-badge--top {margin-top: -1 * $base-increment;}
-    &.w-badge--bottom {margin-bottom: -1 * $base-increment;}
-    &.w-badge--left {margin-right: -3 * $base-increment;}
-    &.w-badge--right {margin-left: -3 * $base-increment;}
-    &.w-badge--top.size--xs {margin-top: round(-0.5 * $base-increment);}
-    &.w-badge--bottom.size--xs {margin-bottom: round(-0.5 * $base-increment);}
-    &.w-badge--top.size--sm {margin-top: round(-0.75 * $base-increment);}
-    &.w-badge--bottom.size--sm {margin-bottom: round(-0.75 * $base-increment);}
-    &.w-badge--top.size--lg {margin-top: round(-1.5 * $base-increment);}
-    &.w-badge--bottom.size--lg {margin-bottom: round(-1.5 * $base-increment);}
-    &.w-badge--top.size--xl {margin-top: -2 * $base-increment;}
-    &.w-badge--bottom.size--xl {margin-bottom: -2 * $base-increment;}
-  }
+    &--inline {position: static;}
 
-  // Look modifiers.
-  &--dark {color: rgba(255, 255, 255, 0.95);}
-  &--outline {
-    background-color: transparent;
-    border-color: currentColor;
-  }
-  &--shadow {box-shadow: $box-shadow;}
+    &--round {
+      aspect-ratio: 1;
+      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+      padding: 0;
+    }
 
-  &--dot.w-badge {min-width: 0;padding: 0;aspect-ratio: 1;}
-  &--dot.size--xs {height: round(1.35 * $base-increment);}
-  &--dot.size--sm {height: round(1.7 * $base-increment);}
-  &--dot.size--md {height: round(2.2 * $base-increment);}
-  &--dot.size--lg {height: round(2.75 * $base-increment);}
-  &--dot.size--xl {height: 3 * $base-increment;}
+    // Sizes.
+    &.size--xs {
+      // Always get an even number for better text vertical alignment.
+      $height: round(divide($base-font-size, 2)) * 2;
+      font-size: round(0.67 * divide($base-font-size, 2)) * 2;
+      height: $height;
+      line-height: $height;
+      min-width: $height;
+
+      &--round {width: $height;padding: 0 round(divide($height, 2));}
+    }
+    &.size--sm {
+      $height: round(1.1 * divide($base-font-size, 2)) * 2;
+      font-size: round(0.75 * divide($base-font-size, 2)) * 2;
+      height: $height;
+      line-height: $height;
+      min-width: $height;
+    }
+    &.size--md {
+      $height: round(1.3 * divide($base-font-size, 2)) * 2;
+      font-size: round(0.9 * divide($base-font-size, 2)) * 2;
+      height: $height;
+      line-height: $height;
+      min-width: $height;
+    }
+    &.size--lg {
+      $height: round(1.5 * divide($base-font-size, 2)) * 2;
+      font-size: round(1.05 * divide($base-font-size, 2)) * 2;
+      height: $height;
+      line-height: $height;
+      min-width: $height;
+    }
+    &.size--xl {
+      $height: round(1.8 * divide($base-font-size, 2)) * 2;
+      font-size: round(1.2 * divide($base-font-size, 2)) * 2;
+      height: $height;
+      line-height: $height;
+      min-width: $height;
+    }
+
+    // Position.
+    &--top {top: 0;}
+    &--bottom {bottom: 0;}
+    &--left {right: 100%;}
+    &--right {left: 100%;}
+    &--overlap {
+      &.w-badge--top {margin-top: -1 * $base-increment;}
+      &.w-badge--bottom {margin-bottom: -1 * $base-increment;}
+      &.w-badge--left {margin-right: -3 * $base-increment;}
+      &.w-badge--right {margin-left: -3 * $base-increment;}
+      &.w-badge--top.size--xs {margin-top: round(-0.5 * $base-increment);}
+      &.w-badge--bottom.size--xs {margin-bottom: round(-0.5 * $base-increment);}
+      &.w-badge--top.size--sm {margin-top: round(-0.75 * $base-increment);}
+      &.w-badge--bottom.size--sm {margin-bottom: round(-0.75 * $base-increment);}
+      &.w-badge--top.size--lg {margin-top: round(-1.5 * $base-increment);}
+      &.w-badge--bottom.size--lg {margin-bottom: round(-1.5 * $base-increment);}
+      &.w-badge--top.size--xl {margin-top: -2 * $base-increment;}
+      &.w-badge--bottom.size--xl {margin-bottom: -2 * $base-increment;}
+    }
+
+    // Look modifiers.
+    &--dark {color: rgba(255, 255, 255, 0.95);}
+    &--outline {
+      background-color: transparent;
+      border-color: currentColor;
+    }
+    &--shadow {box-shadow: $box-shadow;}
+
+    &--dot.w-badge {min-width: 0;padding: 0;aspect-ratio: 1;}
+    &--dot.size--xs {height: round(1.35 * $base-increment);}
+    &--dot.size--sm {height: round(1.7 * $base-increment);}
+    &--dot.size--md {height: round(2.2 * $base-increment);}
+    &--dot.size--lg {height: round(2.75 * $base-increment);}
+    &--dot.size--xl {height: 3 * $base-increment;}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-breadcrumbs.vue
+++ b/src/wave-ui/components/w-breadcrumbs.vue
@@ -85,19 +85,21 @@ export default {
 </script>
 
 <style lang="scss">
-.w-breadcrumbs {
-  display: flex;
-  align-items: center;
+#{$css-scope} {
+  .w-breadcrumbs {
+    display: flex;
+    align-items: center;
 
-  &.size--xs {font-size: round(0.8 * $base-font-size);}
-  &.size--sm {font-size: round(0.9 * $base-font-size);}
-  &.size--md {font-size: round(1.05 * $base-font-size);}
-  &.size--lg {font-size: round(1.2 * $base-font-size);}
-  &.size--xl {font-size: round(1.4 * $base-font-size);}
+    &.size--xs {font-size: round(0.8 * $base-font-size);}
+    &.size--sm {font-size: round(0.9 * $base-font-size);}
+    &.size--md {font-size: round(1.05 * $base-font-size);}
+    &.size--lg {font-size: round(1.2 * $base-font-size);}
+    &.size--xl {font-size: round(1.4 * $base-font-size);}
 
-  &__separator {
-    margin-left: $base-increment;
-    margin-right: $base-increment;
+    &__separator {
+      margin-left: $base-increment;
+      margin-right: $base-increment;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-button/button.vue
+++ b/src/wave-ui/components/w-button/button.vue
@@ -141,184 +141,186 @@ export default {
 <style lang="scss">
 $spinner-size: 40;
 
-.w-button {
-  position: relative;
-  display: inline-flex;
-  flex-shrink: 0;
-  outline: none;
-  border-radius: $border-radius;
-  background-color: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(0, 0, 0, 0.04);
-  padding-left: 2 * $base-increment;
-  padding-right: 2 * $base-increment;
-  box-shadow: 0 0 0 transparent;
-  vertical-align: middle;
-  align-self: center;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  user-select: none;
-  cursor: pointer;
-  color: inherit; // Override the default color in Safari.
-  font-family: inherit;
-  z-index: 1;
-  // Background-color must not transition to not affect the hover & focus states
-  // in :before & :after.
-  transition: all $transition-duration, background-color 0s, padding 0s;
-  -webkit-tap-highlight-color: transparent;
-
-  @include themeable;
-
-  // In w-flex wrapper, allow overriding the default `align-self: center`.
-  .w-flex.align-start > & {align-self: flex-start;}
-  .w-flex.align-end > & {align-self: flex-end;}
-
-  // Position.
-  &--absolute {position: absolute;}
-  &--fixed {position: fixed;}
-  &--top {top: 2 * $base-increment;}
-  &--bottom {bottom: 2 * $base-increment;}
-  &--left {left: 2 * $base-increment;}
-  &--right {right: 2 * $base-increment;}
-
-  &--dark {
-    color: rgba(255, 255, 255, 0.95);
-    background-color: rgba(255, 255, 255, 0.15);
-  }
-  &--outline {
-    background-color: transparent;
-    border-color: currentColor;
-  }
-  &--text {
-    background-color: transparent;
-    border-color: transparent;
-  }
-  &--round {
-    border-radius: 99em;
-    padding-left: 3 * $base-increment;
-    padding-right: 3 * $base-increment;
-  }
-  &--icon {
-    aspect-ratio: 1;
-    border-radius: 99em;
-    padding: 0;
-    min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-  }
-  &--tile {border-radius: initial;}
-  &--shadow {box-shadow: $box-shadow;}
-  &--loading {cursor: wait;opacity: 0.8;}
-  &[disabled] {
-    cursor: not-allowed;
-    box-shadow: none;
-    opacity: 0.4;
-    -webkit-tap-highlight-color: transparent;
-  }
-  &--dark[disabled] {
-    background-color: rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.3);
-  }
-
-  // Sizes adjustments (always an even number for easier vertical alignments).
-  &.size--xs {height: round(1.25 * divide($base-font-size, 2)) * 2;}
-  &.size--sm {height: round(1.55 * divide($base-font-size, 2)) * 2;}
-  &.size--md {height: round(1.85 * divide($base-font-size, 2)) * 2;}
-  &.size--lg {height: round(2.2 * divide($base-font-size, 2)) * 2;}
-  &.size--xl {height: round(2.5 * divide($base-font-size, 2)) * 2;}
-
-  &.size--xs {padding-left: $base-increment;padding-right: $base-increment;}
-  &.size--xl {padding-left: 3 * $base-increment;padding-right: 3 * $base-increment;}
-  &--round.size--xs {padding-left: round(1.5 * $base-increment);padding-right: round(1.5 * $base-increment);}
-  &--round.size--xl {padding-left: round(4.5 * $base-increment);padding-right: round(4.5 * $base-increment);}
-  &--icon.size--xs {padding-left: 0;padding-right: 0;}
-  &--icon.size--xl {padding-left: 0;padding-right: 0;}
-
-  // Overlay to mark the focus, hover and active state.
-  &:before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    background-color: #000;
-    border-radius: inherit;
-    @include default-transition;
-  }
-
-  &--dark:before, &.primary--bg:before,
-  &.success--bg:before, &.error--bg:before, &.warning--bg:before, &.info--bg:before {background-color: #fff;}
-  &--outline:before, &--text:before {background-color: currentColor;}
-
-  // Button states.
-  // ------------------------------------------------------
-  // Hover & focus states - inside button.
-  &:hover:before, &:focus-visible:before {opacity: 0.2;}
-  &--dark:hover:before, &--dark:focus-visible:before {opacity: 0.4;}
-  &--outline:hover:before, &--outline:focus-visible:before,
-  &--text:hover:before, &--text:focus-visible:before {opacity: 0.12;}
-
-  // Focus state - outside button.
-  &:after {
-    content: '';
-    position: absolute;
-    top: -4px;
-    left: -4px;
-    right: -4px;
-    bottom: -4px;
-    background-color: inherit;
-    opacity: 0;
-    border-radius: inherit;
-    z-index: -1;
-    transition: opacity 0.2s cubic-bezier(0.45, 0.05, 0.55, 0.95), transform 0.25s ease-in;
-    transform: scale(0.85, 0.7);
-  }
-  &:focus-visible:after {
-    opacity: 0.4;
-    transform: scale(1);
-    transition: opacity 0.2s cubic-bezier(0.45, 0.05, 0.55, 0.95), transform 0.25s ease-out;
-  }
-  &--dark:focus-visible:after {opacity: 0.2;}
-
-  // Active state.
-  &:active {transform: scale(1.02);}
-  &:active:before {
-    opacity: 0.3;
-    @include default-transition($fast-transition-duration);
-  }
-  &--dark:active:before, &.primary--bg:active:before {opacity: 0.35;}
-
-  // Disable visual feedback on loading and disabled buttons.
-  &--loading:hover:before,
-  &--loading:focus-visible:before,
-  &--loading:active:before,
-  &[disabled]:before {opacity: 0;}
-  &--loading:active,
-  &[disabled] {transform: none;}
-  // ------------------------------------------------------
-
-  // Disable events binding on nested content.
-  & * {pointer-events: none;}
-
-  &__loader {
-    position: absolute;
-    inset: 0;
-    display: flex;
+#{$css-scope} {
+  .w-button {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+    outline: none;
+    border-radius: $border-radius;
+    background-color: rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.04);
+    padding-left: 2 * $base-increment;
+    padding-right: 2 * $base-increment;
+    box-shadow: 0 0 0 transparent;
+    vertical-align: middle;
+    align-self: center;
     align-items: center;
     justify-content: center;
-    background: inherit;
-    border-radius: inherit;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    user-select: none;
+    cursor: pointer;
+    color: inherit; // Override the default color in Safari.
+    font-family: inherit;
+    z-index: 1;
+    // Background-color must not transition to not affect the hover & focus states
+    // in :before & :after.
+    transition: all $transition-duration, background-color 0s, padding 0s;
+    -webkit-tap-highlight-color: transparent;
 
-    svg {height: 75%;}
-    circle {
-      stroke-dasharray: (3.14 * $spinner-size);
-      transform-origin: 50%;
-      animation: spinner 2s linear infinite;
+    @include themeable;
+
+    // In w-flex wrapper, allow overriding the default `align-self: center`.
+    .w-flex.align-start > & {align-self: flex-start;}
+    .w-flex.align-end > & {align-self: flex-end;}
+
+    // Position.
+    &--absolute {position: absolute;}
+    &--fixed {position: fixed;}
+    &--top {top: 2 * $base-increment;}
+    &--bottom {bottom: 2 * $base-increment;}
+    &--left {left: 2 * $base-increment;}
+    &--right {right: 2 * $base-increment;}
+
+    &--dark {
+      color: rgba(255, 255, 255, 0.95);
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+    &--outline {
+      background-color: transparent;
+      border-color: currentColor;
+    }
+    &--text {
+      background-color: transparent;
+      border-color: transparent;
+    }
+    &--round {
+      border-radius: 99em;
+      padding-left: 3 * $base-increment;
+      padding-right: 3 * $base-increment;
+    }
+    &--icon {
+      aspect-ratio: 1;
+      border-radius: 99em;
+      padding: 0;
+      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+    }
+    &--tile {border-radius: initial;}
+    &--shadow {box-shadow: $box-shadow;}
+    &--loading {cursor: wait;opacity: 0.8;}
+    &[disabled] {
+      cursor: not-allowed;
+      box-shadow: none;
+      opacity: 0.4;
+      -webkit-tap-highlight-color: transparent;
+    }
+    &--dark[disabled] {
+      background-color: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.3);
+    }
+
+    // Sizes adjustments (always an even number for easier vertical alignments).
+    &.size--xs {height: round(1.25 * divide($base-font-size, 2)) * 2;}
+    &.size--sm {height: round(1.55 * divide($base-font-size, 2)) * 2;}
+    &.size--md {height: round(1.85 * divide($base-font-size, 2)) * 2;}
+    &.size--lg {height: round(2.2 * divide($base-font-size, 2)) * 2;}
+    &.size--xl {height: round(2.5 * divide($base-font-size, 2)) * 2;}
+
+    &.size--xs {padding-left: $base-increment;padding-right: $base-increment;}
+    &.size--xl {padding-left: 3 * $base-increment;padding-right: 3 * $base-increment;}
+    &--round.size--xs {padding-left: round(1.5 * $base-increment);padding-right: round(1.5 * $base-increment);}
+    &--round.size--xl {padding-left: round(4.5 * $base-increment);padding-right: round(4.5 * $base-increment);}
+    &--icon.size--xs {padding-left: 0;padding-right: 0;}
+    &--icon.size--xl {padding-left: 0;padding-right: 0;}
+
+    // Overlay to mark the focus, hover and active state.
+    &:before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      background-color: #000;
+      border-radius: inherit;
+      @include default-transition;
+    }
+
+    &--dark:before, &.primary--bg:before,
+    &.success--bg:before, &.error--bg:before, &.warning--bg:before, &.info--bg:before {background-color: #fff;}
+    &--outline:before, &--text:before {background-color: currentColor;}
+
+    // Button states.
+    // ------------------------------------------------------
+    // Hover & focus states - inside button.
+    &:hover:before, &:focus-visible:before {opacity: 0.2;}
+    &--dark:hover:before, &--dark:focus-visible:before {opacity: 0.4;}
+    &--outline:hover:before, &--outline:focus-visible:before,
+    &--text:hover:before, &--text:focus-visible:before {opacity: 0.12;}
+
+    // Focus state - outside button.
+    &:after {
+      content: '';
+      position: absolute;
+      top: -4px;
+      left: -4px;
+      right: -4px;
+      bottom: -4px;
+      background-color: inherit;
+      opacity: 0;
+      border-radius: inherit;
+      z-index: -1;
+      transition: opacity 0.2s cubic-bezier(0.45, 0.05, 0.55, 0.95), transform 0.25s ease-in;
+      transform: scale(0.85, 0.7);
+    }
+    &:focus-visible:after {
+      opacity: 0.4;
+      transform: scale(1);
+      transition: opacity 0.2s cubic-bezier(0.45, 0.05, 0.55, 0.95), transform 0.25s ease-out;
+    }
+    &--dark:focus-visible:after {opacity: 0.2;}
+
+    // Active state.
+    &:active {transform: scale(1.02);}
+    &:active:before {
+      opacity: 0.3;
+      @include default-transition($fast-transition-duration);
+    }
+    &--dark:active:before, &.primary--bg:active:before {opacity: 0.35;}
+
+    // Disable visual feedback on loading and disabled buttons.
+    &--loading:hover:before,
+    &--loading:focus-visible:before,
+    &--loading:active:before,
+    &[disabled]:before {opacity: 0;}
+    &--loading:active,
+    &[disabled] {transform: none;}
+    // ------------------------------------------------------
+
+    // Disable events binding on nested content.
+    & * {pointer-events: none;}
+
+    &__loader {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: inherit;
+      border-radius: inherit;
+
+      svg {height: 75%;}
+      circle {
+        stroke-dasharray: (3.14 * $spinner-size);
+        transform-origin: 50%;
+        animation: spinner 2s linear infinite;
+      }
     }
   }
-}
 
-@keyframes spinner {
-  0% {transform: rotate(0deg);stroke-dashoffset: (0.66 * $spinner-size);}
-  50% {transform: rotate(720deg);stroke-dashoffset: (3.14 * $spinner-size);}
-  100% {transform: rotate(1080deg);stroke-dashoffset: (0.66 * $spinner-size);}
+  @keyframes spinner {
+    0% {transform: rotate(0deg);stroke-dashoffset: (0.66 * $spinner-size);}
+    50% {transform: rotate(720deg);stroke-dashoffset: (3.14 * $spinner-size);}
+    100% {transform: rotate(1080deg);stroke-dashoffset: (0.66 * $spinner-size);}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-card.vue
+++ b/src/wave-ui/components/w-card.vue
@@ -84,61 +84,63 @@ export default {
 </script>
 
 <style lang="scss">
-.w-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  border-radius: $border-radius;
-  border: $border;
-
-  @include themeable;
-
-  &--tile {border-radius: 0;}
-  &--shadow {box-shadow: $box-shadow;}
-  &--no-border, &--shadow {border: none;}
-
-  &__title {
+#{$css-scope} {
+  .w-card {
+    position: relative;
     display: flex;
-    align-items: center;
-    padding: (2 * $base-increment) (3 * $base-increment);
-    font-size: 1.3em;
-    border-bottom: $border;
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
+    flex-direction: column;
+    border-radius: $border-radius;
+    border: $border;
 
-    &--has-toolbar {padding: 0;border-bottom: none;}
-  }
+    @include themeable;
 
-  // When there is no title apply the border radius to the image.
-  &__image:first-child {
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
-    overflow: hidden;
-  }
+    &--tile {border-radius: 0;}
+    &--shadow {box-shadow: $box-shadow;}
+    &--no-border, &--shadow {border: none;}
 
-  &__content {
-    padding: 3 * $base-increment;
-    flex-grow: 1;
-
-    // Only if there is no title bar.
-    &:first-child {
+    &__title {
+      display: flex;
+      align-items: center;
+      padding: (2 * $base-increment) (3 * $base-increment);
+      font-size: 1.3em;
+      border-bottom: $border;
       border-top-left-radius: inherit;
       border-top-right-radius: inherit;
+
+      &--has-toolbar {padding: 0;border-bottom: none;}
     }
-    &:last-child {
-    // Only if there is no actions bar.
+
+    // When there is no title apply the border radius to the image.
+    &__image:first-child {
+      border-top-left-radius: inherit;
+      border-top-right-radius: inherit;
+      overflow: hidden;
+    }
+
+    &__content {
+      padding: 3 * $base-increment;
+      flex-grow: 1;
+
+      // Only if there is no title bar.
+      &:first-child {
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
+      }
+      &:last-child {
+      // Only if there is no actions bar.
+        border-bottom-left-radius: inherit;
+        border-bottom-right-radius: inherit;
+      }
+    }
+
+    &__actions {
+      display: flex;
+      padding: (2 * $base-increment) (3 * $base-increment) (3 * $base-increment);
       border-bottom-left-radius: inherit;
       border-bottom-right-radius: inherit;
+
+      &--has-toolbar {padding: 0;}
     }
-  }
-
-  &__actions {
-    display: flex;
-    padding: (2 * $base-increment) (3 * $base-increment) (3 * $base-increment);
-    border-bottom-left-radius: inherit;
-    border-bottom-right-radius: inherit;
-
-    &--has-toolbar {padding: 0;}
   }
 }
 </style>

--- a/src/wave-ui/components/w-checkbox.vue
+++ b/src/wave-ui/components/w-checkbox.vue
@@ -145,143 +145,145 @@ export default {
 $outline-width: 2px;
 $inactive-color: #666;
 
-.w-checkbox {
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-  // Contain the hidden radio button, so browser doesn't pan to it when outside of the screen.
-  position: relative;
-  -webkit-tap-highlight-color: transparent;
-
-  @include themeable;
-
-  // The hidden real checkbox.
-  input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    z-index: -100;
-    outline: none;
-  }
-
-  // The fake checkbox to substitute.
-  &__input {
-    position: relative;
-    width: $small-form-el-size;
-    aspect-ratio: 1;
-    display: flex;
-    flex: 0 0 auto; // Prevent stretching width or height.
+#{$css-scope} {
+  .w-checkbox {
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 0;
-
-    .w-checkbox--disabled & {cursor: not-allowed;}
-  }
-
-  // The checkmark - visible when checked.
-  &__input svg {
-    width: 70%;
-    aspect-ratio: 1;
-    fill: none;
-    stroke-width: 2;
-    stroke: $contrast-color;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-dasharray: 16px;
-    stroke-dashoffset: 16px;
-    transition: $transition-duration ease-out;
-    opacity: 0;
+    vertical-align: middle;
+    // Contain the hidden radio button, so browser doesn't pan to it when outside of the screen.
     position: relative;
-    z-index: 1;
+    -webkit-tap-highlight-color: transparent;
 
-    :checked ~ & {
-      opacity: 1;
-      stroke-dashoffset: 0;
-      transition: stroke-dashoffset 0.5s 0.1s, opacity 0s;
+    @include themeable;
+
+    // The hidden real checkbox.
+    input[type="checkbox"] {
+      position: absolute;
+      opacity: 0;
+      z-index: -100;
+      outline: none;
     }
 
-    .w-checkbox--indeterminate & {opacity: 0;}
-    .w-checkbox--disabled & {stroke: rgba(var(--w-contrast-color-rgb), 0.4);}
-  }
+    // The fake checkbox to substitute.
+    &__input {
+      position: relative;
+      width: $small-form-el-size;
+      aspect-ratio: 1;
+      display: flex;
+      flex: 0 0 auto; // Prevent stretching width or height.
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      z-index: 0;
 
-  &__input:after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    aspect-ratio: 1;
-    border: $outline-width solid $inactive-color;
-    border-radius: $border-radius;
-    transition: $transition-duration ease-in-out;
+      .w-checkbox--disabled & {cursor: not-allowed;}
+    }
 
-    .w-checkbox--round & {border-radius: 100%;}
-    .w-checkbox--disabled & {border-color: $disabled-color;}
+    // The checkmark - visible when checked.
+    &__input svg {
+      width: 70%;
+      aspect-ratio: 1;
+      fill: none;
+      stroke-width: 2;
+      stroke: $contrast-color;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 16px;
+      stroke-dashoffset: 16px;
+      transition: $transition-duration ease-out;
+      opacity: 0;
+      position: relative;
+      z-index: 1;
 
-    // Checked state.
-    :checked ~ & {
-      border-width: divide($small-form-el-size, 2);
-      border-color: currentColor;
-      // Prevents a tiny hole while animating and in some browser zoom levels.
+      :checked ~ & {
+        opacity: 1;
+        stroke-dashoffset: 0;
+        transition: stroke-dashoffset 0.5s 0.1s, opacity 0s;
+      }
+
+      .w-checkbox--indeterminate & {opacity: 0;}
+      .w-checkbox--disabled & {stroke: rgba(var(--w-contrast-color-rgb), 0.4);}
+    }
+
+    &__input:after {
+      content: '';
+      position: absolute;
+      width: 100%;
+      aspect-ratio: 1;
+      border: $outline-width solid $inactive-color;
+      border-radius: $border-radius;
+      transition: $transition-duration ease-in-out;
+
+      .w-checkbox--round & {border-radius: 100%;}
+      .w-checkbox--disabled & {border-color: $disabled-color;}
+
+      // Checked state.
+      :checked ~ & {
+        border-width: divide($small-form-el-size, 2);
+        border-color: currentColor;
+        // Prevents a tiny hole while animating and in some browser zoom levels.
+        background-color: currentColor;
+      }
+      .w-checkbox--indeterminate :checked ~ & {
+        border-width: ((divide($small-form-el-size, 2)) - 1px) 3px;
+        background-color: $contrast-color;
+      }
+      .w-checkbox--disabled :checked ~ & {
+        border-color: $disabled-color;
+        // Prevents a tiny hole while animating and in some browser zoom levels.
+        background-color: rgba(var(--w-contrast-color-rgb), 0.4);
+      }
+    }
+
+    // The focus outline & ripple on check action.
+    &__input:before {
+      content: "";
+      position: absolute;
+      width: inherit;
+      aspect-ratio: 1;
       background-color: currentColor;
+      border-radius: 100%;
+      transform: scale(0);
+      opacity: 0;
+      pointer-events: none;
+      transition: 0.25s ease-in-out;
     }
-    .w-checkbox--indeterminate :checked ~ & {
-      border-width: ((divide($small-form-el-size, 2)) - 1px) 3px;
-      background-color: $contrast-color;
+
+    &--ripple &__input:before {
+      background-color: transparent;
+      animation: w-checkbox-ripple 0.55s 0.15s ease;
     }
-    .w-checkbox--disabled :checked ~ & {
-      border-color: $disabled-color;
-      // Prevents a tiny hole while animating and in some browser zoom levels.
-      background-color: rgba(var(--w-contrast-color-rgb), 0.4);
+
+    :focus ~ &__input:before,
+    &:not(.w-checkbox--disabled) :active ~ &__input:before {
+      transform: scale(1.8);
+      opacity: 0.2;
     }
-  }
 
-  // The focus outline & ripple on check action.
-  &__input:before {
-    content: "";
-    position: absolute;
-    width: inherit;
-    aspect-ratio: 1;
-    background-color: currentColor;
-    border-radius: 100%;
-    transform: scale(0);
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.25s ease-in-out;
-  }
+    // After ripple reset to default state, then remove the class via js and the
+    // `:focus + &__input:before` will re-transition to normal focused outline.
+    &--rippled &__input:before {
+      transition: none;
+      transform: scale(0);
+      opacity: 0;
+    }
 
-  &--ripple &__input:before {
-    background-color: transparent;
-    animation: w-checkbox-ripple 0.55s 0.15s ease;
-  }
+    &__label {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
 
-  :focus ~ &__input:before,
-  &:not(.w-checkbox--disabled) :active ~ &__input:before {
-    transform: scale(1.8);
-    opacity: 0.2;
-  }
-
-  // After ripple reset to default state, then remove the class via js and the
-  // `:focus + &__input:before` will re-transition to normal focused outline.
-  &--rippled &__input:before {
-    transition: none;
-    transform: scale(0);
-    opacity: 0;
-  }
-
-  &__label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-
-    .w-checkbox--disabled & {
-      cursor: not-allowed;
-      opacity: 0.7;
+      .w-checkbox--disabled & {
+        cursor: not-allowed;
+        opacity: 0.7;
+      }
     }
   }
-}
 
-@keyframes w-checkbox-ripple {
-  0% {opacity: 0.8;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
-  100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
+  @keyframes w-checkbox-ripple {
+    0% {opacity: 0.8;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
+    100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
+  }
 }
 </style>

--- a/src/wave-ui/components/w-checkboxes.vue
+++ b/src/wave-ui/components/w-checkboxes.vue
@@ -112,20 +112,22 @@ export default {
 </script>
 
 <style lang="scss">
-.w-checkboxes {
-  &--column {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
+#{$css-scope} {
+  .w-checkboxes {
+    &--column {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
 
-  &--inline {
-    display: inline-flex;
-    flex-wrap: wrap;
-    vertical-align: middle;
+    &--inline {
+      display: inline-flex;
+      flex-wrap: wrap;
+      vertical-align: middle;
 
-    .w-checkbox {margin-right: 3 * $base-increment;}
-    .w-checkbox:last-child {margin-right: 0;}
+      .w-checkbox {margin-right: 3 * $base-increment;}
+      .w-checkbox:last-child {margin-right: 0;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-date-picker.vue
+++ b/src/wave-ui/components/w-date-picker.vue
@@ -28,8 +28,10 @@ export default {
 </script>
 
 <style lang="scss">
-.w-date-picker {
+#{$css-scope} {
+  .w-date-picker {
 
-  @include themeable;
+    @include themeable;
+  }
 }
 </style>

--- a/src/wave-ui/components/w-dialog.vue
+++ b/src/wave-ui/components/w-dialog.vue
@@ -118,21 +118,23 @@ export default {
 </script>
 
 <style lang="scss">
-.w-dialog {
-  &__content {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    max-width: 95%;
-    overflow: auto;
-    background-color: $dialog-bg-color;
+#{$css-scope} {
+  .w-dialog {
+    &__content {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      max-width: 95%;
+      overflow: auto;
+      background-color: $dialog-bg-color;
 
-    @include themeable;
+      @include themeable;
 
-    .w-dialog--fullscreen > & {
-      flex: 1 1 auto;
-      height: 100%;
-      max-width: none;
+      .w-dialog--fullscreen > & {
+        flex: 1 1 auto;
+        height: 100%;
+        max-width: none;
+      }
     }
   }
 }

--- a/src/wave-ui/components/w-divider.vue
+++ b/src/wave-ui/components/w-divider.vue
@@ -34,50 +34,52 @@ export default {
 </script>
 
 <style lang="scss">
-.w-divider {
-  border: 0 solid $divider-color;
-  border-top-width: 1px;
+#{$css-scope} {
+  .w-divider {
+    border: 0 solid $divider-color;
+    border-top-width: 1px;
 
-  @include themeable;
+    @include themeable;
 
-  &--has-color {border-color: currentColor;}
+    &--has-color {border-color: currentColor;}
 
-  &--vertical {
-    align-self: stretch; // Fill up the available height.
-    display: flex;
-    border-top-width: 0;
-    border-left-width: 1px;
-  }
-
-  .w-toolbar--vertical > &--horizontal {
-    align-self: stretch; // Fill up the available width.
-  }
-
-  // With a slot.
-  &--has-content {
-    border-width: 0;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    // Horizontal.
-    &:before, &:after {
-      content: '';
-      border: inherit;
-      border-top-width: 1px;
+    &--vertical {
+      align-self: stretch; // Fill up the available height.
       display: flex;
-      flex: 1 1 auto;
+      border-top-width: 0;
+      border-left-width: 1px;
     }
-    &:before {margin-right: 2 * $base-increment;}
-    &:after {margin-left: 2 * $base-increment;}
 
-    // Vertical.
-    &.w-divider--vertical {
-      flex-direction: column;
-      &:before, &:after {border-top-width: 0;border-left-width: 1px;}
-      &:before {margin-right: 0;margin-bottom: 2 * $base-increment;}
-      &:after {margin-left: 0;margin-top: 2 * $base-increment;}
+    .w-toolbar--vertical > &--horizontal {
+      align-self: stretch; // Fill up the available width.
+    }
+
+    // With a slot.
+    &--has-content {
+      border-width: 0;
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      // Horizontal.
+      &:before, &:after {
+        content: '';
+        border: inherit;
+        border-top-width: 1px;
+        display: flex;
+        flex: 1 1 auto;
+      }
+      &:before {margin-right: 2 * $base-increment;}
+      &:after {margin-left: 2 * $base-increment;}
+
+      // Vertical.
+      &.w-divider--vertical {
+        flex-direction: column;
+        &:before, &:after {border-top-width: 0;border-left-width: 1px;}
+        &:before {margin-right: 0;margin-bottom: 2 * $base-increment;}
+        &:after {margin-left: 0;margin-top: 2 * $base-increment;}
+      }
     }
   }
 }

--- a/src/wave-ui/components/w-drawer.vue
+++ b/src/wave-ui/components/w-drawer.vue
@@ -199,81 +199,83 @@ export default {
 </script>
 
 <style lang="scss">
-.w-drawer-wrap {
-  &--fixed {position: fixed;z-index: 500;}
+#{$css-scope} {
+  .w-drawer-wrap {
+    &--fixed {position: fixed;z-index: 500;}
 
-  &--absolute {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-  }
-
-  .w-overlay {z-index: 1;position: inherit;}
-
-  &--push-content {
-    position: relative;
-    overflow: hidden;
-    height: 100%;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-
-    .w-overlay {
+    &--absolute {
       position: absolute;
       inset: 0;
-      z-index: 2;
+      overflow: hidden;
     }
-    .w-drawer {position: absolute;}
-    .w-drawer--left {right: 100%;left: auto !important;}
-    .w-drawer--right {left: 100%;}
+
+    .w-overlay {z-index: 1;position: inherit;}
+
+    &--push-content {
+      position: relative;
+      overflow: hidden;
+      height: 100%;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+
+      .w-overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 2;
+      }
+      .w-drawer {position: absolute;}
+      .w-drawer--left {right: 100%;left: auto !important;}
+      .w-drawer--right {left: 100%;}
+    }
+
+    &__track {
+      display: flex;
+      flex: 1;
+      height: 100%;
+      @include default-transition;
+    }
+
+    &__pushable {
+      position: relative;
+      flex-grow: 1;
+    }
   }
 
-  &__track {
+  .w-drawer {
+    position: inherit;
     display: flex;
-    flex: 1;
-    height: 100%;
-    @include default-transition;
+    z-index: 1;
+    background: $drawer-bg-color;
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.3);
+
+    @include themeable;
+
+    &--left, &--right {
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      max-width: $drawer-max-size;
+    }
+    &--top, &--bottom {
+      left: 0;
+      right: 0;
+      height: 100%;
+      max-height: $drawer-max-size;
+    }
+    &--fit-content {width: auto;height: auto;}
+
+    &--left {left: 0;}
+    &--right {right: 0;}
+    &--top {top: 0;}
+    &--bottom {bottom: 0;}
+
+    &--persistent-animate {animation: 0.2s w-drawer-pop cubic-bezier(0.6, -0.28, 0.74, 0.05);}
   }
 
-  &__pushable {
-    position: relative;
-    flex-grow: 1;
+  @keyframes w-drawer-pop {
+    0%, 100% {transform: scale(1);}
+    50% {transform: scale(1.05);}
   }
-}
-
-.w-drawer {
-  position: inherit;
-  display: flex;
-  z-index: 1;
-  background: $drawer-bg-color;
-  box-shadow: 0 0 40px rgba(0, 0, 0, 0.3);
-
-  @include themeable;
-
-  &--left, &--right {
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    max-width: $drawer-max-size;
-  }
-  &--top, &--bottom {
-    left: 0;
-    right: 0;
-    height: 100%;
-    max-height: $drawer-max-size;
-  }
-  &--fit-content {width: auto;height: auto;}
-
-  &--left {left: 0;}
-  &--right {right: 0;}
-  &--top {top: 0;}
-  &--bottom {bottom: 0;}
-
-  &--persistent-animate {animation: 0.2s w-drawer-pop cubic-bezier(0.6, -0.28, 0.74, 0.05);}
-}
-
-@keyframes w-drawer-pop {
-  0%, 100% {transform: scale(1);}
-  50% {transform: scale(1.05);}
 }
 </style>

--- a/src/wave-ui/components/w-flex.vue
+++ b/src/wave-ui/components/w-flex.vue
@@ -56,14 +56,16 @@ export default {
 </script>
 
 <style lang="scss">
-.w-flex {
-  display: flex;
-  flex: 1 1 auto;
+#{$css-scope} {
+  .w-flex {
+    display: flex;
+    flex: 1 1 auto;
 
-  &.row {flex-direction: row;}
-  &.column {flex-direction: column;}
-  &.wrap {flex-wrap: wrap;}
-  &.basis-zero > * {flex-basis: 0;flex-grow: 1;}
-  &.basis-zero > .no-grow, &.basis-zero > .shrink {flex-grow: 0;}
+    &.row {flex-direction: row;}
+    &.column {flex-direction: column;}
+    &.wrap {flex-wrap: wrap;}
+    &.basis-zero > * {flex-basis: 0;flex-grow: 1;}
+    &.basis-zero > .no-grow, &.basis-zero > .shrink {flex-grow: 0;}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-form-element.vue
+++ b/src/wave-ui/components/w-form-element.vue
@@ -106,38 +106,40 @@ export default {
 </script>
 
 <style lang="scss">
-div.w-form-el {
-  flex-direction: column;
-  justify-content: center;
-  align-items: stretch;
-}
-
-.w-form-el {
-  > .w-flex {position: relative;}
-  .w-form--error-placeholders & {
-    position: relative;
-    padding-bottom: 1.2rem;
+#{$css-scope} {
+  div.w-form-el {
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
   }
-  &--has-error input::placeholder {color: inherit;}
 
-  &-shakable {position: relative;}
-  &--error &-shakable {animation: w-form-el-shake 0.3s $transition-duration ease-in-out;}
+  .w-form-el {
+    > .w-flex {position: relative;}
+    .w-form--error-placeholders & {
+      position: relative;
+      padding-bottom: 1.2rem;
+    }
+    &--has-error input::placeholder {color: inherit;}
 
-  // Error message.
-  // ------------------------------------------------------
-  &__error {
-    width: 100%;
-    flex-grow: 1;
-    font-size: 0.775rem;
-    margin-top: $base-increment;
+    &-shakable {position: relative;}
+    &--error &-shakable {animation: w-form-el-shake 0.3s $transition-duration ease-in-out;}
 
-    .w-form--error-placeholders & {position: absolute;bottom: 0;}
+    // Error message.
+    // ------------------------------------------------------
+    &__error {
+      width: 100%;
+      flex-grow: 1;
+      font-size: 0.775rem;
+      margin-top: $base-increment;
+
+      .w-form--error-placeholders & {position: absolute;bottom: 0;}
+    }
   }
-}
 
-@keyframes w-form-el-shake {
-  0% {left: 0;}
-  20%, 60% {left: 2px;}
-  40%, 80% {left: -2px;}
+  @keyframes w-form-el-shake {
+    0% {left: 0;}
+    20%, 60% {left: 2px;}
+    40%, 80% {left: -2px;}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-grid.vue
+++ b/src/wave-ui/components/w-grid.vue
@@ -72,11 +72,13 @@ export default {
 </script>
 
 <style lang="scss">
-.w-grid {
-  display: grid;
+#{$css-scope} {
+  .w-grid {
+    display: grid;
 
-  @for $i from 1 through 12 {
-    &.columns#{$i} {grid-template-columns: repeat($i, 1fr);}
+    @for $i from 1 through 12 {
+      &.columns#{$i} {grid-template-columns: repeat($i, 1fr);}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-icon.vue
+++ b/src/wave-ui/components/w-icon.vue
@@ -99,56 +99,58 @@ export default {
 </script>
 
 <style lang="scss">
-.w-icon {
-  position: relative;
-  display: inline-flex;
-  border-radius: 100%;
-  align-items: center;
-  justify-content: center;
-  vertical-align: middle;
-  user-select: none;
-  speak: never;
-  line-height: 1;
-  font-size: 1.2em;
-  width: 1em;
-  // The aspect ratio will not work if the content overflows (needs overflow hidden, but we don't want that in the library).
-  height: 1em;
+#{$css-scope} {
+  .w-icon {
+    position: relative;
+    display: inline-flex;
+    border-radius: 100%;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    user-select: none;
+    speak: never;
+    line-height: 1;
+    font-size: 1.2em;
+    width: 1em;
+    // The aspect ratio will not work if the content overflows (needs overflow hidden, but we don't want that in the library).
+    height: 1em;
 
-  &.size--xs {font-size: round(0.85 * $base-font-size);}
-  &.size--sm {font-size: round(1.15 * $base-font-size);}
-  &.size--md {font-size: round(1.4 * $base-font-size);}
-  &.size--lg {font-size: round(1.7 * $base-font-size);}
-  &.size--xl {font-size: 2 * $base-font-size;}
+    &.size--xs {font-size: round(0.85 * $base-font-size);}
+    &.size--sm {font-size: round(1.15 * $base-font-size);}
+    &.size--md {font-size: round(1.4 * $base-font-size);}
+    &.size--lg {font-size: round(1.7 * $base-font-size);}
+    &.size--xl {font-size: 2 * $base-font-size;}
 
-  // Always an even number to align well vertically in a button.
-  .w-button.size--xs & {font-size: round(0.95 * divide($base-font-size, 2)) * 2;}
-  .w-alert.size--xs & {font-size: $base-font-size;}
-  .w-button.size--sm &, .w-alert.size--sm & {font-size: round(1.15 * $base-font-size);}
-  // .w-button.size--md &, .w-alert.size--md & {font-size: round(1.4 * $base-font-size);}
-  .w-button.size--lg &, .w-alert.size--lg & {font-size: round(1.7 * $base-font-size);}
-  .w-button.size--xl &, .w-alert.size--xl & {font-size: 2 * $base-font-size;}
+    // Always an even number to align well vertically in a button.
+    .w-button.size--xs & {font-size: round(0.95 * divide($base-font-size, 2)) * 2;}
+    .w-alert.size--xs & {font-size: $base-font-size;}
+    .w-button.size--sm &, .w-alert.size--sm & {font-size: round(1.15 * $base-font-size);}
+    // .w-button.size--md &, .w-alert.size--md & {font-size: round(1.4 * $base-font-size);}
+    .w-button.size--lg &, .w-alert.size--lg & {font-size: round(1.7 * $base-font-size);}
+    .w-button.size--xl &, .w-alert.size--xl & {font-size: 2 * $base-font-size;}
 
-  &:before {transition: transform $transition-duration;}
-  &--spin:before {animation: w-icon--spin 2s infinite linear;}
-  &--spin-a:before {animation: w-icon--spin-a 2s infinite linear;}
-  &--rotate45:before {transform: rotate(45deg);}
-  &--rotate90:before {transform: rotate(90deg);}
-  &--rotate135:before {transform: rotate(135deg);}
-  &--rotate180:before {transform: rotate(180deg);}
-  &--rotate-45:before {transform: rotate(-45deg);}
-  &--rotate-90:before {transform: rotate(-90deg);}
-  &--rotate-135:before {transform: rotate(-135deg);}
-  &--flip-x:before {transform: scaleX(-1);}
-  &--flip-y:before {transform: scaleY(-1);}
-}
+    &:before {transition: transform $transition-duration;}
+    &--spin:before {animation: w-icon--spin 2s infinite linear;}
+    &--spin-a:before {animation: w-icon--spin-a 2s infinite linear;}
+    &--rotate45:before {transform: rotate(45deg);}
+    &--rotate90:before {transform: rotate(90deg);}
+    &--rotate135:before {transform: rotate(135deg);}
+    &--rotate180:before {transform: rotate(180deg);}
+    &--rotate-45:before {transform: rotate(-45deg);}
+    &--rotate-90:before {transform: rotate(-90deg);}
+    &--rotate-135:before {transform: rotate(-135deg);}
+    &--flip-x:before {transform: scaleX(-1);}
+    &--flip-y:before {transform: scaleY(-1);}
+  }
 
-@keyframes w-icon--spin {
-  0% {transform: rotate(0deg);}
-  to {transform: rotate(359deg);}
-}
+  @keyframes w-icon--spin {
+    0% {transform: rotate(0deg);}
+    to {transform: rotate(359deg);}
+  }
 
-@keyframes w-icon--spin-a {
-  0% {transform: rotate(0deg);}
-  to {transform: rotate(-359deg);}
+  @keyframes w-icon--spin-a {
+    0% {transform: rotate(0deg);}
+    to {transform: rotate(-359deg);}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-image.vue
+++ b/src/wave-ui/components/w-image.vue
@@ -174,39 +174,41 @@ export default {
 </script>
 
 <style lang="scss">
-.w-image-wrap {
-  position: relative;
-  display: inline-flex;
-  flex-grow: 0;
-  flex-shrink: 0;
-  width: 4em;
+#{$css-scope} {
+  .w-image-wrap {
+    position: relative;
+    display: inline-flex;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 4em;
 
-  &--has-ratio {width: 100%;}
-  &[class^="bdrs"], &[class*=" bdrs"] {overflow: hidden;}
+    &--has-ratio {width: 100%;}
+    &[class^="bdrs"], &[class*=" bdrs"] {overflow: hidden;}
 
-  img {
-    width: 100%;
-    height: auto;
-    position: static;
+    img {
+      width: 100%;
+      height: auto;
+      position: static;
+    }
   }
-}
 
-.w-image {
-  background-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'); // 1x1 blank gif.
-  background-repeat: no-repeat;
-  background-size: cover;
-  position: absolute;
-  inset: 0;
-
-  &--contain {background-size: contain;}
-
-  &__loader, &__content {
+  .w-image {
+    background-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'); // 1x1 blank gif.
+    background-repeat: no-repeat;
+    background-size: cover;
     position: absolute;
     inset: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1;
+
+    &--contain {background-size: contain;}
+
+    &__loader, &__content {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-input.vue
+++ b/src/wave-ui/components/w-input.vue
@@ -380,262 +380,264 @@ export default {
 <style lang="scss">
 $inactive-color: #777;
 
-.w-input {
-  position: relative;
-  display: flex;
-  flex-grow: 1;
-  flex-wrap: wrap;
-  align-items: center;
-  font-size: $base-font-size;
-
-  &--file {
-    flex-wrap: nowrap;
-    align-items: flex-end;
-
-    span.fade-leave-to {position: absolute;}
-  }
-
-  &--loading {cursor: wait;}
-
-  // Input field wrapper.
-  // ------------------------------------------------------
-  &__input-wrap {
+#{$css-scope} {
+  .w-input {
     position: relative;
-    display: inline-flex;
-    flex: 1 1 auto;
-    align-items: center;
-    height: $form-field-height;
-    border-radius: $border-radius;
-    border: $border;
-    transition: border $transition-duration;
-
-    .w-input--floating-label & {margin-top: 3 * $base-increment;}
-    .w-input[class^="bdrs"] &, .w-input[class*=" bdrs"] & {border-radius: inherit;}
-
-    // https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
-    &--file {min-width: 0;}
-
-    &--underline {
-      border-bottom-left-radius: initial;
-      border-bottom-right-radius: initial;
-      border-width: 0 0 1px;
-    }
-
-    &--round {border-radius: 99em;}
-    &--tile {border-radius: initial;}
-    &--shadow {box-shadow: $box-shadow;}
-    &--loading, &--upload-complete {
-      border-bottom-color: transparent;
-      flex-wrap: wrap;
-    }
-    &--loading ~ .w-progress {
-      height: 2px;
-      position: absolute;
-      top: 100%;
-      margin-top: -2px;
-    }
-
-    .w-input--focused & {border-color: currentColor;}
-    .w-input--focused &--loading,
-    .w-input--focused &--upload-complete {border-bottom-color: transparent;}
-
-    // Underline.
-    &--underline:after {
-      content: '';
-      position: absolute;
-      bottom: -1px;
-      left: 0;
-      width: 100%;
-      height: 0;
-      border-bottom: 2px solid currentColor;
-      transition: $transition-duration;
-      transform: scaleX(0);
-      pointer-events: none;
-    }
-
-    &--loading:after {border-bottom-color: transparent;}
-
-    .w-input--focused &--underline:after {transform: scaleX(1);}
-    &--round.w-input__input-wrap--underline:after {
-      border-radius: 99em;
-      transition: $transition-duration, height 0.035s;
-    }
-    .w-input--focused &--round.w-input__input-wrap--underline:after {
-      height: 100%;
-      transition: $transition-duration, height 0s ($transition-duration - 0.035s);
-    }
-  }
-
-  // Input field.
-  // ------------------------------------------------------
-  &__input {
-    width: 100%;
-    height: 100%;
-    font: inherit;
-    color: inherit;
-    text-align: inherit;
-    display: inline-flex;
-    align-items: center;
-    background: none;
-    border: none;
-    outline: none;
-    padding-left: 2 * $base-increment;
-    padding-right: 2 * $base-increment;
-
-    // For type="search" on Safari.
-    -webkit-appearance: none;
-    &::-webkit-search-decoration {-webkit-appearance: none;}
-  }
-
-  &--no-padding &__input {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  &__input-wrap--round &__input {
-    padding-left: 3 * $base-increment;
-    padding-right: 3 * $base-increment;
-  }
-
-  &--inner-icon-left &__input {padding-left: 27px;}
-  &--inner-icon-right &__input {padding-right: 27px;}
-
-  &--disabled &__input {
-    color: $disabled-color;
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  &--disabled input::placeholder {color: inherit;}
-
-  // Upload field.
-  // ------------------------------------------------------
-  // Hides the built-in file input (replaced with a more stylable element).
-  input[type="file"] {
-    position: absolute;
-    z-index: -1;
-    pointer-events: none;
-    opacity: 0;
-  }
-
-  &__input--file {
-    > span {
-      display: inline-flex;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .filename {
-      margin-left: 0.2em;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    > span:first-child .filename {margin-left: 0;}
-  }
-
-  &__no-file {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
     display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
     align-items: center;
-    color: $disabled-color;
-  }
+    font-size: $base-font-size;
 
-  &__file-preview {
-    margin-left: 4px;
-    max-height: 2em;
-    align-self: flex-end;
+    &--file {
+      flex-wrap: nowrap;
+      align-items: flex-end;
 
-    &.w-icon {margin-bottom: 4px;}
-  }
+      span.fade-leave-to {position: absolute;}
+    }
 
-  // Icons inside.
-  // ------------------------------------------------------
-  &__icon {position: absolute;}
-  &__icon--inner-left {left: 6px;}
-  &__icon--inner-right {right: 6px;}
-  &--no-padding &__icon--inner-left {left: 1px;}
-  &--no-padding &__icon--inner-right {right: 1px;}
+    &--loading {cursor: wait;}
 
-  .w-input--focused &__icon {color: currentColor;}
+    // Input field wrapper.
+    // ------------------------------------------------------
+    &__input-wrap {
+      position: relative;
+      display: inline-flex;
+      flex: 1 1 auto;
+      align-items: center;
+      height: $form-field-height;
+      border-radius: $border-radius;
+      border: $border;
+      transition: border $transition-duration;
 
-  &--disabled &__icon {
-    color: $disabled-color;
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
-  }
+      .w-input--floating-label & {margin-top: 3 * $base-increment;}
+      .w-input[class^="bdrs"] &, .w-input[class*=" bdrs"] & {border-radius: inherit;}
 
-  // Label.
-  // ------------------------------------------------------
-  &__label {
-    transition: color $transition-duration;
-    cursor: pointer;
-    user-select: none;
+      // https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
+      &--file {min-width: 0;}
 
-    &--left {margin-right: 2 * $base-increment;}
-    &--right {margin-left: 2 * $base-increment;}
+      &--underline {
+        border-bottom-left-radius: initial;
+        border-bottom-right-radius: initial;
+        border-width: 0 0 1px;
+      }
 
-    .w-input--disabled & {
+      &--round {border-radius: 99em;}
+      &--tile {border-radius: initial;}
+      &--shadow {box-shadow: $box-shadow;}
+      &--loading, &--upload-complete {
+        border-bottom-color: transparent;
+        flex-wrap: wrap;
+      }
+      &--loading ~ .w-progress {
+        height: 2px;
+        position: absolute;
+        top: 100%;
+        margin-top: -2px;
+      }
+
+      .w-input--focused & {border-color: currentColor;}
+      .w-input--focused &--loading,
+      .w-input--focused &--upload-complete {border-bottom-color: transparent;}
+
+      // Underline.
+      &--underline:after {
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 100%;
+        height: 0;
+        border-bottom: 2px solid currentColor;
+        transition: $transition-duration;
+        transform: scaleX(0);
+        pointer-events: none;
+      }
+
+      &--loading:after {border-bottom-color: transparent;}
+
+      .w-input--focused &--underline:after {transform: scaleX(1);}
+      &--round.w-input__input-wrap--underline:after {
+        border-radius: 99em;
+        transition: $transition-duration, height 0.035s;
+      }
+      .w-input--focused &--round.w-input__input-wrap--underline:after {
+        height: 100%;
+        transition: $transition-duration, height 0s ($transition-duration - 0.035s);
+      }
+    }
+
+    // Input field.
+    // ------------------------------------------------------
+    &__input {
+      width: 100%;
+      height: 100%;
+      font: inherit;
+      color: inherit;
+      text-align: inherit;
+      display: inline-flex;
+      align-items: center;
+      background: none;
+      border: none;
+      outline: none;
+      padding-left: 2 * $base-increment;
+      padding-right: 2 * $base-increment;
+
+      // For type="search" on Safari.
+      -webkit-appearance: none;
+      &::-webkit-search-decoration {-webkit-appearance: none;}
+    }
+
+    &--no-padding &__input {
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    &__input-wrap--round &__input {
+      padding-left: 3 * $base-increment;
+      padding-right: 3 * $base-increment;
+    }
+
+    &--inner-icon-left &__input {padding-left: 27px;}
+    &--inner-icon-right &__input {padding-right: 27px;}
+
+    &--disabled &__input {
       color: $disabled-color;
       cursor: not-allowed;
       -webkit-tap-highlight-color: transparent;
     }
-    .w-input--readonly.w-input--empty & {
-      opacity: 0.5;
-      cursor: auto;
+
+    &--disabled input::placeholder {color: inherit;}
+
+    // Upload field.
+    // ------------------------------------------------------
+    // Hides the built-in file input (replaced with a more stylable element).
+    input[type="file"] {
+      position: absolute;
+      z-index: -1;
+      pointer-events: none;
+      opacity: 0;
     }
-  }
 
-  &__label--inside {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    padding-left: 2 * $base-increment;
-    white-space: nowrap;
-    transform: translateY(-50%);
-    pointer-events: none;
+    &__input--file {
+      > span {
+        display: inline-flex;
+        overflow: hidden;
+        white-space: nowrap;
+      }
 
-    .w-input--no-padding & {
+      .filename {
+        margin-left: 0.2em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      > span:first-child .filename {margin-left: 0;}
+    }
+
+    &__no-file {
+      position: absolute;
+      top: 0;
+      bottom: 0;
       left: 0;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    .w-input__input-wrap--round & {
-      padding-left: round(3 * $base-increment);
-      padding-right: round(3 * $base-increment);
-    }
-    .w-input--inner-icon-left & {left: 18px;}
-    .w-input--no-padding.w-input--inner-icon-left & {left: 26px;}
-
-    .w-input--floating-label & {
-      transform-origin: 0 0;
-      transition: $transition-duration ease;
-      will-change: transform;
+      display: flex;
+      align-items: center;
+      color: $disabled-color;
     }
 
-    // move label with underline style.
-    .w-input--focused.w-input--floating-label &,
-    .w-input--filled.w-input--floating-label &,
-    .w-input--has-placeholder.w-input--floating-label & {
-      transform: translateY(-160%) scale(0.85);
+    &__file-preview {
+      margin-left: 4px;
+      max-height: 2em;
+      align-self: flex-end;
+
+      &.w-icon {margin-bottom: 4px;}
     }
-    // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
-    .w-input--floating-label .w-input__input:-webkit-autofill & {
-      transform: translateY(-160%) scale(0.85);
+
+    // Icons inside.
+    // ------------------------------------------------------
+    &__icon {position: absolute;}
+    &__icon--inner-left {left: 6px;}
+    &__icon--inner-right {right: 6px;}
+    &--no-padding &__icon--inner-left {left: 1px;}
+    &--no-padding &__icon--inner-right {right: 1px;}
+
+    .w-input--focused &__icon {color: currentColor;}
+
+    &--disabled &__icon {
+      color: $disabled-color;
+      cursor: not-allowed;
+      -webkit-tap-highlight-color: transparent;
     }
-    // Move label with outline style or with shadow.
-    .w-input--focused.w-input--floating-label .w-input__input-wrap--box &,
-    .w-input--filled.w-input--floating-label .w-input__input-wrap--box &,
-    .w-input--has-placeholder.w-input--floating-label .w-input__input-wrap--box & {
-      transform: translateY(-180%) scale(0.85);
+
+    // Label.
+    // ------------------------------------------------------
+    &__label {
+      transition: color $transition-duration;
+      cursor: pointer;
+      user-select: none;
+
+      &--left {margin-right: 2 * $base-increment;}
+      &--right {margin-left: 2 * $base-increment;}
+
+      .w-input--disabled & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .w-input--readonly.w-input--empty & {
+        opacity: 0.5;
+        cursor: auto;
+      }
     }
-    .w-input--focused.w-input--floating-label.w-input--inner-icon-left &,
-    .w-input--filled.w-input--floating-label.w-input--inner-icon-left & {left: 0;}
-    // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
-    .w-input--floating-label.w-input--inner-icon-left .w-input__input:-webkit-autofill & {left: 0;}
+
+    &__label--inside {
+      position: absolute;
+      top: 50%;
+      left: 0;
+      padding-left: 2 * $base-increment;
+      white-space: nowrap;
+      transform: translateY(-50%);
+      pointer-events: none;
+
+      .w-input--no-padding & {
+        left: 0;
+        padding-left: 0;
+        padding-right: 0;
+      }
+      .w-input__input-wrap--round & {
+        padding-left: round(3 * $base-increment);
+        padding-right: round(3 * $base-increment);
+      }
+      .w-input--inner-icon-left & {left: 18px;}
+      .w-input--no-padding.w-input--inner-icon-left & {left: 26px;}
+
+      .w-input--floating-label & {
+        transform-origin: 0 0;
+        transition: $transition-duration ease;
+        will-change: transform;
+      }
+
+      // move label with underline style.
+      .w-input--focused.w-input--floating-label &,
+      .w-input--filled.w-input--floating-label &,
+      .w-input--has-placeholder.w-input--floating-label & {
+        transform: translateY(-160%) scale(0.85);
+      }
+      // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
+      .w-input--floating-label .w-input__input:-webkit-autofill & {
+        transform: translateY(-160%) scale(0.85);
+      }
+      // Move label with outline style or with shadow.
+      .w-input--focused.w-input--floating-label .w-input__input-wrap--box &,
+      .w-input--filled.w-input--floating-label .w-input__input-wrap--box &,
+      .w-input--has-placeholder.w-input--floating-label .w-input__input-wrap--box & {
+        transform: translateY(-180%) scale(0.85);
+      }
+      .w-input--focused.w-input--floating-label.w-input--inner-icon-left &,
+      .w-input--filled.w-input--floating-label.w-input--inner-icon-left & {left: 0;}
+      // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
+      .w-input--floating-label.w-input--inner-icon-left .w-input__input:-webkit-autofill & {left: 0;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-list.vue
+++ b/src/wave-ui/components/w-list.vue
@@ -387,107 +387,109 @@ export default {
 </script>
 
 <style lang="scss">
-.w-list {
-  list-style-type: none;
-  margin-left: 0;
-  font-size: $base-font-size;
+#{$css-scope} {
+  .w-list {
+    list-style-type: none;
+    margin-left: 0;
+    font-size: $base-font-size;
 
-  &--child {margin-left: 6 * $base-increment;}
-  &--icon {padding-left: 8 * $base-increment;}
+    &--child {margin-left: 6 * $base-increment;}
+    &--icon {padding-left: 8 * $base-increment;}
 
-  &__item {margin-top: 1px;}
-  &__item:first-child {margin-top: 0;}
-  &--icon &__item {position: relative;}
+    &__item {margin-top: 1px;}
+    &__item:first-child {margin-top: 0;}
+    &--icon &__item {position: relative;}
 
-  &__item--parent {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  // List item bullet, if any.
-  // --------------------------------------------
-  &__item-bullet {
-    position: absolute;
-    right: 100%;
-    margin-right: 3 * $base-increment;
-    top: 0.1em;
-
-    @-moz-document url-prefix() {
-      & {top: -0.06em;}
+    &__item--parent {
+      flex-direction: column;
+      align-items: stretch;
     }
 
-    .w-list--hoverable &,
-    .w-list--selectable &,
-    .w-list--checklist & {margin-top: 3 * $base-increment;}
-  }
+    // List item bullet, if any.
+    // --------------------------------------------
+    &__item-bullet {
+      position: absolute;
+      right: 100%;
+      margin-right: 3 * $base-increment;
+      top: 0.1em;
 
-  // List item Label.
-  // --------------------------------------------
-  &__item-label {
-    position: relative;
-    padding-top: 1px;
-    padding-bottom: 1px;
-    display: flex;
-    -webkit-tap-highlight-color: transparent;
-
-    .w-list--navigation &,
-    .w-list--checklist & {
-      display: flex;
-      align-items: center;
-    }
-    &--selectable {cursor: pointer;}
-    &--disabled {
-      cursor: default;
-      opacity: 0.3;
-      user-select: none;
-    }
-
-    &--hoverable,
-    &--selectable {
-      padding: 2 * $base-increment;
-
-      &:before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background-color: currentColor;
-        opacity: 0;
-        transition: 0.2s;
-        pointer-events: none;
+      @-moz-document url-prefix() {
+        & {top: -0.06em;}
       }
+
+      .w-list--hoverable &,
+      .w-list--selectable &,
+      .w-list--checklist & {margin-top: 3 * $base-increment;}
     }
 
-    // Hover & focus states.
-    &--hoverable:hover:before,
-    &--selectable:focus:before,
-    &--focused:before,
-    &--selectable:hover:before {opacity: 0.08;}
+    // List item Label.
+    // --------------------------------------------
+    &__item-label {
+      position: relative;
+      padding-top: 1px;
+      padding-bottom: 1px;
+      display: flex;
+      -webkit-tap-highlight-color: transparent;
 
-    // Active class (when item is selected).
-    &--active:before, &--active:focus:before, &--active:hover:before,
-    .w-list--navigation &.router-link-exact-active:before {opacity: 0.15;}
+      .w-list--navigation &,
+      .w-list--checklist & {
+        display: flex;
+        align-items: center;
+      }
+      &--selectable {cursor: pointer;}
+      &--disabled {
+        cursor: default;
+        opacity: 0.3;
+        user-select: none;
+      }
 
-    // Active state (while pressing key or mouse).
-    &--active.w-list__item-label--hoverable:hover:before,
-    &--active.w-list__item-label--selectable:focus:before,
-    &--active.w-list__item-label--selectable:hover:before,
-    &--selectable:active:before {opacity: 0.2;}
+      &--hoverable,
+      &--selectable {
+        padding: 2 * $base-increment;
 
-    // Disabled.
-    &--disabled:before {display: none;}
+        &:before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          background-color: currentColor;
+          opacity: 0;
+          transition: 0.2s;
+          pointer-events: none;
+        }
+      }
+
+      // Hover & focus states.
+      &--hoverable:hover:before,
+      &--selectable:focus:before,
+      &--focused:before,
+      &--selectable:hover:before {opacity: 0.08;}
+
+      // Active class (when item is selected).
+      &--active:before, &--active:focus:before, &--active:hover:before,
+      .w-list--navigation &.router-link-exact-active:before {opacity: 0.15;}
+
+      // Active state (while pressing key or mouse).
+      &--active.w-list__item-label--hoverable:hover:before,
+      &--active.w-list__item-label--selectable:focus:before,
+      &--active.w-list__item-label--selectable:hover:before,
+      &--selectable:active:before {opacity: 0.2;}
+
+      // Disabled.
+      &--disabled:before {display: none;}
+    }
+    // --------------------------------------------
+
+    // Checklist.
+    // --------------------------------------------
+    &--checklist .w-checkbox__label {flex-grow: 1;}
+    // &--checklist .w-checkbox * {pointer-events: none;}
+    // --------------------------------------------
+
+    // Navigation link.
+    // --------------------------------------------
+    &--navigation a {color: inherit;}
+    &--navigation .router-link-exact-active {font-weight: bold;}
+    // --------------------------------------------
   }
-  // --------------------------------------------
-
-  // Checklist.
-  // --------------------------------------------
-  &--checklist .w-checkbox__label {flex-grow: 1;}
-  // &--checklist .w-checkbox * {pointer-events: none;}
-  // --------------------------------------------
-
-  // Navigation link.
-  // --------------------------------------------
-  &--navigation a {color: inherit;}
-  &--navigation .router-link-exact-active {font-weight: bold;}
-  // --------------------------------------------
 }
 </style>

--- a/src/wave-ui/components/w-menu.vue
+++ b/src/wave-ui/components/w-menu.vue
@@ -282,36 +282,38 @@ export default {
 </script>
 
 <style lang="scss">
-.w-menu-wrap {display: none;}
+#{$css-scope} {
+  .w-menu-wrap {display: none;}
 
-.w-menu {
-  position: absolute;
-  z-index: 100;
-  color: $menu-color;
+  .w-menu {
+    position: absolute;
+    z-index: 100;
+    color: $menu-color;
 
-  @include themeable;
+    @include themeable;
 
-  &--fixed {position: fixed;z-index: 1000;}
-  &--card {background-color: $menu-bg-color;}
-  &--tile {border-radius: 0;}
-  &--round {
-    border-radius: 99em;
-    padding: $base-increment round(2.5 * $base-increment);
-  }
-  &--shadow {box-shadow: $box-shadow;}
+    &--fixed {position: fixed;z-index: 1000;}
+    &--card {background-color: $menu-bg-color;}
+    &--tile {border-radius: 0;}
+    &--round {
+      border-radius: 99em;
+      padding: $base-increment round(2.5 * $base-increment);
+    }
+    &--shadow {box-shadow: $box-shadow;}
 
-  &--top {margin-top: -3 * $base-increment;}
-  &--bottom {margin-top: 3 * $base-increment;}
-  &--left {margin-left: -3 * $base-increment;}
-  &--right {margin-left: 3 * $base-increment;}
+    &--top {margin-top: -3 * $base-increment;}
+    &--bottom {margin-top: 3 * $base-increment;}
+    &--left {margin-left: -3 * $base-increment;}
+    &--right {margin-left: 3 * $base-increment;}
 
-  &--arrow {
-    &.w-menu--top {margin-top: -4 * $base-increment;}
-    &.w-menu--bottom {margin-top: 4 * $base-increment;}
-    &.w-menu--left {margin-left: -4 * $base-increment;}
-    &.w-menu--right {margin-left: 4 * $base-increment;}
+    &--arrow {
+      &.w-menu--top {margin-top: -4 * $base-increment;}
+      &.w-menu--bottom {margin-top: 4 * $base-increment;}
+      &.w-menu--left {margin-left: -4 * $base-increment;}
+      &.w-menu--right {margin-left: 4 * $base-increment;}
 
-    @include triangle(var(--w-menu-bg-color), '.w-menu', 9px);
+      @include triangle(var(--w-menu-bg-color), '.w-menu', 9px);
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-notification-manager.vue
+++ b/src/wave-ui/components/w-notification-manager.vue
@@ -48,24 +48,26 @@ export default {
 </script>
 
 <style lang="scss">
-.w-notification-manager {
-  position: fixed;
-  inset: 0 0 0 auto;
-  z-index: 1000;
-  pointer-events: none;
-  width: 280px;
-  overflow-x: hidden;
+#{$css-scope} {
+  .w-notification-manager {
+    position: fixed;
+    inset: 0 0 0 auto;
+    z-index: 1000;
+    pointer-events: none;
+    width: 280px;
+    overflow-x: hidden;
 
-  &--left {right: auto;left: 0;}
+    &--left {right: auto;left: 0;}
 
-  .w-alert {
-    position: relative;
-    z-index: 400;
-    left: 0;
-    right: 0;
-    margin: 8px;
-    flex-grow: 1;
-    pointer-events: all;
+    .w-alert {
+      position: relative;
+      z-index: 400;
+      left: 0;
+      right: 0;
+      margin: 8px;
+      flex-grow: 1;
+      pointer-events: all;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-notification.vue
+++ b/src/wave-ui/components/w-notification.vue
@@ -165,27 +165,29 @@ export default {
 </script>
 
 <style lang="scss">
-.w-notification {
-  display: flex;
-  justify-content: center;
-  left: 2 * $base-increment;
-  right: 2 * $base-increment;
-  position: fixed;
-  z-index: 300;
-  pointer-events: none;
+#{$css-scope} {
+  .w-notification {
+    display: flex;
+    justify-content: center;
+    left: 2 * $base-increment;
+    right: 2 * $base-increment;
+    position: fixed;
+    z-index: 300;
+    pointer-events: none;
 
-  @include themeable;
+    @include themeable;
 
-  // Position.
-  &--absolute {position: absolute;z-index: 400;}
-  &--top {top: 0;padding-top: 2 * $base-increment;}
-  &--bottom {bottom: 0;padding-bottom: 2 * $base-increment;}
-  &--left {justify-content: flex-start;right: auto;}
-  &--right {justify-content: flex-end;left: auto;}
+    // Position.
+    &--absolute {position: absolute;z-index: 400;}
+    &--top {top: 0;padding-top: 2 * $base-increment;}
+    &--bottom {bottom: 0;padding-bottom: 2 * $base-increment;}
+    &--left {justify-content: flex-start;right: auto;}
+    &--right {justify-content: flex-end;left: auto;}
 
-  .w-alert {
-    margin: 0;
-    pointer-events: all;
+    .w-alert {
+      margin: 0;
+      pointer-events: all;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-overlay.vue
+++ b/src/wave-ui/components/w-overlay.vue
@@ -100,27 +100,29 @@ export default {
 </script>
 
 <style lang="scss">
-.w-overlay {
-  z-index: 500;
-  position: fixed;
-  // -10px for the `persistent-animate` ease out back animation.
-  top: -10px;
-  left: -10px;
-  bottom: -10px;
-  right: -10px;
-  padding: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.3);
+#{$css-scope} {
+  .w-overlay {
+    z-index: 500;
+    position: fixed;
+    // -10px for the `persistent-animate` ease out back animation.
+    top: -10px;
+    left: -10px;
+    bottom: -10px;
+    right: -10px;
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(0, 0, 0, 0.3);
 
-  &--absolute {position: absolute;}
-  &--persistent-animate {animation: 0.15s w-overlay-pop cubic-bezier(0.6, -0.28, 0.74, 0.05);}
-  &--no-pointer-event {pointer-events: none;}
-}
+    &--absolute {position: absolute;}
+    &--persistent-animate {animation: 0.15s w-overlay-pop cubic-bezier(0.6, -0.28, 0.74, 0.05);}
+    &--no-pointer-event {pointer-events: none;}
+  }
 
-@keyframes w-overlay-pop {
-  0%, 100% {transform: scale(1);}
-  50% {transform: scale(1.04);}
+  @keyframes w-overlay-pop {
+    0%, 100% {transform: scale(1);}
+    50% {transform: scale(1.04);}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-parallax.vue
+++ b/src/wave-ui/components/w-parallax.vue
@@ -18,6 +18,8 @@ export default {
 </script>
 
 <style lang="scss">
-.w-parallax {
+#{$css-scope} {
+  .w-parallax {
+  }
 }
 </style>

--- a/src/wave-ui/components/w-progress.vue
+++ b/src/wave-ui/components/w-progress.vue
@@ -124,158 +124,160 @@ export default {
 <style lang="scss">
 $circle-size: 40;
 
-.w-progress {
-  align-items: center;
-  justify-content: center;
-  position: relative;
+#{$css-scope} {
+  .w-progress {
+    align-items: center;
+    justify-content: center;
+    position: relative;
 
-  &--absolute, &--fixed {left: 0;right: 0;}
-  &--absolute {position: absolute;}
-  &--fixed {position: fixed;z-index: 10;}
-  &--top {top: 0;}
-  &--bottom {bottom: 0;}
+    &--absolute, &--fixed {left: 0;right: 0;}
+    &--absolute {position: absolute;}
+    &--fixed {position: fixed;z-index: 10;}
+    &--top {top: 0;}
+    &--bottom {bottom: 0;}
 
-  &--shadow {box-shadow: $box-shadow;}
+    &--shadow {box-shadow: $box-shadow;}
 
-  // Linear progress.
-  // ------------------------------------------------------
-  &--linear {border-radius: $border-radius;}
-  // Tile, round and outline are only available on linear progress.
-  &--tile {border-radius: 0;}
-  &--round {border-radius: 99em;}
-  &--outline {border: 1px solid currentColor;padding: 2px;}
+    // Linear progress.
+    // ------------------------------------------------------
+    &--linear {border-radius: $border-radius;}
+    // Tile, round and outline are only available on linear progress.
+    &--tile {border-radius: 0;}
+    &--round {border-radius: 99em;}
+    &--outline {border: 1px solid currentColor;padding: 2px;}
 
-  &--linear {
-    display: flex;
-    height: $base-increment;
-    overflow: hidden;
+    &--linear {
+      display: flex;
+      height: $base-increment;
+      overflow: hidden;
 
-    // Background.
-    &.w-progress--default-bg:after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      background-color: currentColor;
-      opacity: 0.15;
+      // Background.
+      &.w-progress--default-bg:after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background-color: currentColor;
+        opacity: 0.15;
+      }
+      &.w-progress--outline:after {display: none;}
+
+      .w-progress__progress {
+        overflow: hidden;
+        position: relative;
+        width: 100%;
+        height: 100%;
+        justify-self: left;
+        margin-right: auto;
+        border-radius: inherit;
+        background-color: currentColor;
+        @include default-transition;
+      }
+      &.w-progress--flat-cap .w-progress__progress {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+      &.w-progress--round-cap .w-progress__progress,
+      .w-progress__progress.full {border-radius: inherit;}
+
+      &.w-progress--indeterminate .w-progress__progress {
+        background-color: transparent;
+
+        &:before, &:after {
+          content: '';
+          position: absolute;
+          inset: 0 -5% 0 0;
+          background: currentColor;
+          z-index: 1;
+          will-change: transform;
+          transform: translate3d(-100%, 0, 0);
+          animation: w-progress-bars 2s infinite;
+          transform-origin: right;
+        }
+        &:before {animation-delay: 0.8s;}
+      }
     }
-    &.w-progress--outline:after {display: none;}
 
-    .w-progress__progress {
+    // Stripes are only available on linear progress.
+    &--stripes .w-progress__progress {
+      will-change: background-position;
+      background-image: linear-gradient(
+                          -45deg,
+                          rgba(255, 255, 255, 0.2) 25%,
+                          rgba(255, 255, 255, 0) 25%,
+                          rgba(255, 255, 255, 0) 50%,
+                          rgba(255, 255, 255, 0.2) 50%,
+                          rgba(255, 255, 255, 0.2) 75%,
+                          rgba(255, 255, 255, 0) 75%,
+                          rgba(255, 255, 255, 0)
+                        );
+      background-size: 50px 50px;
+      animation: w-progress-stripes 2s infinite linear;
+    }
+
+    // Outline is only available on linear progress.
+    &--outline .w-progress__progress {
       overflow: hidden;
       position: relative;
       width: 100%;
       height: 100%;
       justify-self: left;
       margin-right: auto;
-      border-radius: inherit;
-      background-color: currentColor;
-      @include default-transition;
     }
-    &.w-progress--flat-cap .w-progress__progress {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+
+    // Indeterminate progress.
+    @keyframes w-progress-bars {
+      0% {transform: translate3d(-100%, 0, 0) scaleX(1);}
+      100% {transform: translate3d(0, 0, 0) scaleX(0);}
     }
-    &.w-progress--round-cap .w-progress__progress,
-    .w-progress__progress.full {border-radius: inherit;}
 
-    &.w-progress--indeterminate .w-progress__progress {
-      background-color: transparent;
+    @keyframes w-progress-stripes {
+      0% {background-position: 0 0;}
+      100% {background-position: 50px 50px;}
+    }
+    // ------------------------------------------------------
 
-      &:before, &:after {
-        content: '';
-        position: absolute;
-        inset: 0 -5% 0 0;
-        background: currentColor;
-        z-index: 1;
-        will-change: transform;
-        transform: translate3d(-100%, 0, 0);
-        animation: w-progress-bars 2s infinite;
-        transform-origin: right;
+    // Circular progress.
+    // ------------------------------------------------------
+    &--circular {
+      display: inline-flex;
+      width: 3em;
+      aspect-ratio: 1;
+      font-size: $base-font-size;
+
+      svg {display: block;width: 100%;}
+      circle.bg {stroke: currentColor;}
+      &.w-progress--default-bg circle.bg {stroke: $progress-bg-color;}
+
+      .w-progress__progress {
+        transform-origin: 100% 100%;
+        transform: rotate(-90deg);
+        stroke: currentColor;
+        will-change: stroke-dashoffset;
+        @include default-transition;
       }
-      &:before {animation-delay: 0.8s;}
+      &.w-progress--round-cap .w-progress__progress {stroke-linecap: round;}
+      &.w-progress--indeterminate .w-progress__progress {
+        animation: w-progress-spin 2s linear infinite;
+      }
+
+      @keyframes w-progress-spin {
+        0% {transform: rotate(0deg);stroke-dashoffset: (0.66 * $circle-size);}
+        50% {transform: rotate(720deg);stroke-dashoffset: (3.14 * $circle-size);}
+        100% {transform: rotate(1080deg);stroke-dashoffset: (0.66 * $circle-size);}
+      }
     }
-  }
+    // ------------------------------------------------------
 
-  // Stripes are only available on linear progress.
-  &--stripes .w-progress__progress {
-    will-change: background-position;
-    background-image: linear-gradient(
-                        -45deg,
-                        rgba(255, 255, 255, 0.2) 25%,
-                        rgba(255, 255, 255, 0) 25%,
-                        rgba(255, 255, 255, 0) 50%,
-                        rgba(255, 255, 255, 0.2) 50%,
-                        rgba(255, 255, 255, 0.2) 75%,
-                        rgba(255, 255, 255, 0) 75%,
-                        rgba(255, 255, 255, 0)
-                      );
-    background-size: 50px 50px;
-    animation: w-progress-stripes 2s infinite linear;
-  }
-
-  // Outline is only available on linear progress.
-  &--outline .w-progress__progress {
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    height: 100%;
-    justify-self: left;
-    margin-right: auto;
-  }
-
-  // Indeterminate progress.
-  @keyframes w-progress-bars {
-    0% {transform: translate3d(-100%, 0, 0) scaleX(1);}
-    100% {transform: translate3d(0, 0, 0) scaleX(0);}
-  }
-
-  @keyframes w-progress-stripes {
-    0% {background-position: 0 0;}
-    100% {background-position: 50px 50px;}
-  }
-  // ------------------------------------------------------
-
-  // Circular progress.
-  // ------------------------------------------------------
-  &--circular {
-    display: inline-flex;
-    width: 3em;
-    aspect-ratio: 1;
-    font-size: $base-font-size;
-
-    svg {display: block;width: 100%;}
-    circle.bg {stroke: currentColor;}
-    &.w-progress--default-bg circle.bg {stroke: $progress-bg-color;}
-
-    .w-progress__progress {
-      transform-origin: 100% 100%;
-      transform: rotate(-90deg);
-      stroke: currentColor;
-      will-change: stroke-dashoffset;
-      @include default-transition;
+    &__label {
+      position: absolute;
+      font-weight: bold;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      user-select: none;
     }
-    &.w-progress--round-cap .w-progress__progress {stroke-linecap: round;}
-    &.w-progress--indeterminate .w-progress__progress {
-      animation: w-progress-spin 2s linear infinite;
-    }
-
-    @keyframes w-progress-spin {
-      0% {transform: rotate(0deg);stroke-dashoffset: (0.66 * $circle-size);}
-      50% {transform: rotate(720deg);stroke-dashoffset: (3.14 * $circle-size);}
-      100% {transform: rotate(1080deg);stroke-dashoffset: (0.66 * $circle-size);}
-    }
-  }
-  // ------------------------------------------------------
-
-  &__label {
-    position: absolute;
-    font-weight: bold;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
-    user-select: none;
   }
 }
 </style>

--- a/src/wave-ui/components/w-radio.vue
+++ b/src/wave-ui/components/w-radio.vue
@@ -142,119 +142,121 @@ export default {
 $outline-width: 2px;
 $inactive-color: #666;
 
-.w-radio {
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-  // Contain the hidden radio button, so browser doesn't pan to it when outside of the screen.
-  position: relative;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-
-  @include themeable;
-
-  &--disabled {
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  // The hidden real radio button.
-  input[type="radio"] {
-    position: absolute;
-    opacity: 0;
-    z-index: -100;
-    outline: none;
-  }
-
-  // The fake radio button to substitute.
-  &__input {
+#{$css-scope} {
+  .w-radio {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    // Contain the hidden radio button, so browser doesn't pan to it when outside of the screen.
     position: relative;
-    border-radius: 100%;
-    width: $small-form-el-size;
-    aspect-ratio: 1;
-    display: flex;
-    flex: 0 0 auto; // Prevent stretching width or height.
-    align-items: center;
-    justify-content: center;
-    border: $outline-width solid $inactive-color;
-    transition: 0.3s ease-in-out;
-    cursor: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 
-    .w-radio--disabled & {border-color: $disabled-color;}
+    @include themeable;
 
-    // Checked state.
-    :checked ~ & {border-color: currentColor;}
-    .w-radio--disabled :checked ~ & {border-color: $disabled-color;}
-  }
+    &--disabled {
+      cursor: not-allowed;
+      -webkit-tap-highlight-color: transparent;
+    }
 
-  // The inner bullet - visible when checked.
-  &__input:after {
-    content: '';
-    position: absolute;
-    border-radius: 100%;
-    border: 0 solid $inactive-color;
-    // Prevents a tiny hole while animating and in some browser zoom levels.
-    background-color: $inactive-color;
-    transition: $transition-duration;
+    // The hidden real radio button.
+    input[type="radio"] {
+      position: absolute;
+      opacity: 0;
+      z-index: -100;
+      outline: none;
+    }
 
-    :checked ~ & {
-      border-width: 4px;
-      border-color: currentColor;
+    // The fake radio button to substitute.
+    &__input {
+      position: relative;
+      border-radius: 100%;
+      width: $small-form-el-size;
+      aspect-ratio: 1;
+      display: flex;
+      flex: 0 0 auto; // Prevent stretching width or height.
+      align-items: center;
+      justify-content: center;
+      border: $outline-width solid $inactive-color;
+      transition: 0.3s ease-in-out;
+      cursor: inherit;
+
+      .w-radio--disabled & {border-color: $disabled-color;}
+
+      // Checked state.
+      :checked ~ & {border-color: currentColor;}
+      .w-radio--disabled :checked ~ & {border-color: $disabled-color;}
+    }
+
+    // The inner bullet - visible when checked.
+    &__input:after {
+      content: '';
+      position: absolute;
+      border-radius: 100%;
+      border: 0 solid $inactive-color;
       // Prevents a tiny hole while animating and in some browser zoom levels.
+      background-color: $inactive-color;
+      transition: $transition-duration;
+
+      :checked ~ & {
+        border-width: 4px;
+        border-color: currentColor;
+        // Prevents a tiny hole while animating and in some browser zoom levels.
+        background-color: currentColor;
+      }
+      .w-radio--disabled & {
+        border-color: $disabled-color;
+        // Prevents a tiny hole while animating and in some browser zoom levels.
+        background-color: $disabled-color;
+      }
+    }
+
+    // The focus outline & ripple on check action.
+    &__input:before {
+      content: "";
+      position: absolute;
+      width: inherit;
+      aspect-ratio: 1;
       background-color: currentColor;
+      border-radius: 100%;
+      transform: scale(0);
+      opacity: 0;
+      pointer-events: none;
+      transition: 0.25s ease-in-out;
     }
-    .w-radio--disabled & {
-      border-color: $disabled-color;
-      // Prevents a tiny hole while animating and in some browser zoom levels.
-      background-color: $disabled-color;
+
+    &--ripple &__input:before {
+      background-color: transparent;
+      animation: w-radio-ripple 0.55s 0.15s ease;
+    }
+
+    :focus ~ &__input:before,
+    :active ~ &__input:before {
+      transform: scale(1.8);
+      opacity: 0.2;
+    }
+
+    // After ripple reset to default state, then remove the class via js and the
+    // `:focus + &__input:before` will re-transition to normal focused outline.
+    &--rippled &__input:before {
+      transition: none;
+      transform: scale(0);
+      opacity: 0;
+    }
+
+    &__label {
+      display: flex;
+      align-items: center;
+      cursor: inherit;
+      user-select: none;
+
+      .w-radio--disabled & {opacity: 0.7;}
     }
   }
 
-  // The focus outline & ripple on check action.
-  &__input:before {
-    content: "";
-    position: absolute;
-    width: inherit;
-    aspect-ratio: 1;
-    background-color: currentColor;
-    border-radius: 100%;
-    transform: scale(0);
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.25s ease-in-out;
+  @keyframes w-radio-ripple {
+    0% {opacity: 1;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
+    100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
   }
-
-  &--ripple &__input:before {
-    background-color: transparent;
-    animation: w-radio-ripple 0.55s 0.15s ease;
-  }
-
-  :focus ~ &__input:before,
-  :active ~ &__input:before {
-    transform: scale(1.8);
-    opacity: 0.2;
-  }
-
-  // After ripple reset to default state, then remove the class via js and the
-  // `:focus + &__input:before` will re-transition to normal focused outline.
-  &--rippled &__input:before {
-    transition: none;
-    transform: scale(0);
-    opacity: 0;
-  }
-
-  &__label {
-    display: flex;
-    align-items: center;
-    cursor: inherit;
-    user-select: none;
-
-    .w-radio--disabled & {opacity: 0.7;}
-  }
-}
-
-@keyframes w-radio-ripple {
-  0% {opacity: 1;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
-  100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
 }
 </style>

--- a/src/wave-ui/components/w-radios.vue
+++ b/src/wave-ui/components/w-radios.vue
@@ -97,20 +97,22 @@ export default {
 </script>
 
 <style lang="scss">
-.w-radios {
-  &--column {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
+#{$css-scope} {
+  .w-radios {
+    &--column {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
 
-  &--inline {
-    display: inline-flex;
-    flex-wrap: wrap;
-    vertical-align: middle;
+    &--inline {
+      display: inline-flex;
+      flex-wrap: wrap;
+      vertical-align: middle;
 
-    .w-radio {margin-right: 3 * $base-increment;}
-    .w-radio:last-child {margin-right: 0;}
+      .w-radio {margin-right: 3 * $base-increment;}
+      .w-radio:last-child {margin-right: 0;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-rating.vue
+++ b/src/wave-ui/components/w-rating.vue
@@ -163,119 +163,121 @@ export default {
 </script>
 
 <style lang="scss">
-.w-rating {
-  display: inline-flex;
-  align-items: center;
-
-  @include themeable;
-
-  &__button {
-    position: relative;
-    width: 1.1em;
-    aspect-ratio: 1;
+#{$css-scope} {
+  .w-rating {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    border: none;
-    background: none;
-    color: $rating-bg-color;
-    cursor: pointer;
-    -webkit-tap-highlight-color: transparent;
-    @include default-transition($fast-transition-duration);
+
+    @include themeable;
+
+    &__button {
+      position: relative;
+      width: 1.1em;
+      aspect-ratio: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      background: none;
+      color: $rating-bg-color;
+      cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
+      @include default-transition($fast-transition-duration);
+
+      // Disabled & readonly.
+      .w-rating--disabled & {opacity: 0.6;cursor: not-allowed;}
+      .w-rating--readonly & {cursor: auto;}
+
+      // Sizes.
+      &.size--xs {font-size: round(0.85 * $base-font-size);}
+      &.size--sm {font-size: round(1.15 * $base-font-size);}
+      &.size--md {font-size: round(1.4 * $base-font-size);}
+      &.size--lg {font-size: round(1.7 * $base-font-size);}
+      &.size--xl {font-size: 2 * $base-font-size;margin-left: 0;}
+
+      &:before {font-size: 1.1em;}
+      &:before, .w-icon:before {
+        width: 100%;
+        height: 1em;
+        display: inline-flex;
+        transition: 0.15s transform;
+      }
+    }
+
+    &--hover &__button--on:before,
+    &--hover &__button--on .w-icon:before,
+    &--focus &__button--on:before,
+    &--focus &__button--on .w-icon:before {transform: scale(1.12);}
 
     // Disabled & readonly.
-    .w-rating--disabled & {opacity: 0.6;cursor: not-allowed;}
-    .w-rating--readonly & {cursor: auto;}
+    &--readonly &__button--on:before,
+    &--readonly.w-rating--hover &__button--on:before,
+    &--readonly &__button--on .w-icon:before,
+    &--readonly.w-rating--hover &__button--on .w-icon:before,
+    &--disabled &__button--on:before,
+    &--disabled.w-rating--hover &__button--on:before,
+    &--disabled &__button--on .w-icon:before,
+    &--disabled.w-rating--hover &__button--on .w-icon:before {transform: none;}
 
-    // Sizes.
-    &.size--xs {font-size: round(0.85 * $base-font-size);}
-    &.size--sm {font-size: round(1.15 * $base-font-size);}
-    &.size--md {font-size: round(1.4 * $base-font-size);}
-    &.size--lg {font-size: round(1.7 * $base-font-size);}
-    &.size--xl {font-size: 2 * $base-font-size;margin-left: 0;}
-
-    &:before {font-size: 1.1em;}
-    &:before, .w-icon:before {
+    // Half star.
+    &__button .w-icon {
+      position: absolute;
+      left: 0;
       width: 100%;
-      height: 1em;
+      height: 100%;
+      font-size: 1em;
+      justify-content: flex-start;
+      overflow: hidden;
       display: inline-flex;
-      transition: 0.15s transform;
+      border-radius: 0;
+
+      &:before {padding-left: 0.05em;padding-right: 0.05em;}
     }
+    .w-rating--hover &__button .w-icon {display: none;}
+
+    // The focus outline & ripple on button click.
+    &__button:after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-color: currentColor;
+      border-radius: 100%;
+      transform: translateX(100%) scale(0);
+      opacity: 0;
+      pointer-events: none;
+      transition: 0.25s ease-in-out;
+    }
+
+    &--ripple &__button:focus:after {
+      background-color: transparent;
+      animation: w-rating-ripple 0.55s ease;
+    }
+
+    &__button:focus:after,
+    &__button:active:after {
+      transform: scale(1.8);
+      opacity: 0.2;
+    }
+    &__button--on:focus:after {
+      transform: scale(1.8);
+    }
+    .w-rating--disabled &__button:after,
+    .w-rating--readonly &__button:after {opacity: 0;}
+
+    // After ripple reset to default state, then remove the class via js and the
+    // `:focus + &__button:after` will re-transition to normal focused outline.
+    &--rippled &__button:focus:after {
+      transition: none;
+      transform: scale(0);
+      opacity: 0;
+    }
+
+    &__button * {pointer-events: none;}
   }
 
-  &--hover &__button--on:before,
-  &--hover &__button--on .w-icon:before,
-  &--focus &__button--on:before,
-  &--focus &__button--on .w-icon:before {transform: scale(1.12);}
-
-  // Disabled & readonly.
-  &--readonly &__button--on:before,
-  &--readonly.w-rating--hover &__button--on:before,
-  &--readonly &__button--on .w-icon:before,
-  &--readonly.w-rating--hover &__button--on .w-icon:before,
-  &--disabled &__button--on:before,
-  &--disabled.w-rating--hover &__button--on:before,
-  &--disabled &__button--on .w-icon:before,
-  &--disabled.w-rating--hover &__button--on .w-icon:before {transform: none;}
-
-  // Half star.
-  &__button .w-icon {
-    position: absolute;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    font-size: 1em;
-    justify-content: flex-start;
-    overflow: hidden;
-    display: inline-flex;
-    border-radius: 0;
-
-    &:before {padding-left: 0.05em;padding-right: 0.05em;}
+  @keyframes w-rating-ripple {
+    0% {opacity: 0.8;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
+    100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
   }
-  .w-rating--hover &__button .w-icon {display: none;}
-
-  // The focus outline & ripple on button click.
-  &__button:after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-color: currentColor;
-    border-radius: 100%;
-    transform: translateX(100%) scale(0);
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.25s ease-in-out;
-  }
-
-  &--ripple &__button:focus:after {
-    background-color: transparent;
-    animation: w-rating-ripple 0.55s ease;
-  }
-
-  &__button:focus:after,
-  &__button:active:after {
-    transform: scale(1.8);
-    opacity: 0.2;
-  }
-  &__button--on:focus:after {
-    transform: scale(1.8);
-  }
-  .w-rating--disabled &__button:after,
-  .w-rating--readonly &__button:after {opacity: 0;}
-
-  // After ripple reset to default state, then remove the class via js and the
-  // `:focus + &__button:after` will re-transition to normal focused outline.
-  &--rippled &__button:focus:after {
-    transition: none;
-    transform: scale(0);
-    opacity: 0;
-  }
-
-  &__button * {pointer-events: none;}
-}
-
-@keyframes w-rating-ripple {
-  0% {opacity: 0.8;transform: scale(1);background-color: currentColor;} // Start with visible ripple.
-  100% {opacity: 0;transform: scale(2.8);} // Propagate ripple to max radius and fade out.
 }
 </style>

--- a/src/wave-ui/components/w-scrollable.vue
+++ b/src/wave-ui/components/w-scrollable.vue
@@ -197,47 +197,49 @@ export default {
 </script>
 
 <style lang="scss">
-.w-scrollable {
-  position: relative;
-  overflow: hidden;
-}
-
-.w-scrollbar {
-  position: absolute;
-  background: #000;
-  user-select: none;
-
-  &--horizontal {
-    inset: auto 0 0;
-    height: 8px;
-  }
-  &--vertical {
-    inset: 0 0 0 auto;
-    width: 8px;
+#{$css-scope} {
+  .w-scrollable {
+    position: relative;
+    overflow: hidden;
   }
 
-  &__thumb {
+  .w-scrollbar {
     position: absolute;
-    background: #333;
-    border-radius: $border-radius;
-    z-index: 1;
-    will-change: top left;
+    background: #000;
+    user-select: none;
 
-    &:hover {background: #444;}
-  }
-  &--horizontal &__thumb {
-    height: 6px;
-    left: 0;
-    right: 0;
-    margin-top: 1px;
-    margin-bottom: 1px;
-  }
-  &--vertical &__thumb {
-    width: 6px;
-    top: 0;
-    bottom: 0;
-    margin-left: 1px;
-    margin-right: 1px;
+    &--horizontal {
+      inset: auto 0 0;
+      height: 8px;
+    }
+    &--vertical {
+      inset: 0 0 0 auto;
+      width: 8px;
+    }
+
+    &__thumb {
+      position: absolute;
+      background: #333;
+      border-radius: $border-radius;
+      z-index: 1;
+      will-change: top left;
+
+      &:hover {background: #444;}
+    }
+    &--horizontal &__thumb {
+      height: 6px;
+      left: 0;
+      right: 0;
+      margin-top: 1px;
+      margin-bottom: 1px;
+    }
+    &--vertical &__thumb {
+      width: 6px;
+      top: 0;
+      bottom: 0;
+      margin-left: 1px;
+      margin-right: 1px;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-select.vue
+++ b/src/wave-ui/components/w-select.vue
@@ -422,239 +422,241 @@ export default {
 </script>
 
 <style lang="scss">
-.w-select {
-  position: relative;
-  display: flex;
-  flex-grow: 1;
-  flex-wrap: wrap;
-  align-items: center;
-  font-size: $base-font-size;
-
-  @include themeable;
-
-  &--disabled {
-    color: $disabled-color;
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  &--fit-to-content {
-    display: inline-flex;
-    flex-grow: 0;
-  }
-
-  // Selection wrapper.
-  // ------------------------------------------------------
-  &__selection-wrap {
+#{$css-scope} {
+  .w-select {
     position: relative;
-    display: inline-flex;
-    flex: 1 1 auto;
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
     align-items: center;
-    min-height: $form-field-height; // Min-height to allow multiple lines.
-    border-radius: $border-radius;
-    border: $border;
-    transition: border $transition-duration;
+    font-size: $base-font-size;
 
-    &--tile {border-radius: initial;}
-    &--shadow {box-shadow: $box-shadow;}
-    .w-select[class^="bdrs"] &, .w-select[class*=" bdrs"] & {border-radius: inherit;}
+    @include themeable;
 
-    .w-select--floating-label & {margin-top: 3 * $base-increment;}
-
-    &--underline {
-      border-bottom-left-radius: initial;
-      border-bottom-right-radius: initial;
-      border-width: 0 0 1px;
+    &--disabled {
+      color: $disabled-color;
+      cursor: not-allowed;
+      -webkit-tap-highlight-color: transparent;
     }
 
-    &--round {border-radius: 99em;}
+    &--fit-to-content {
+      display: inline-flex;
+      flex-grow: 0;
+    }
 
-    .w-select--focused &, .w-select--open & {border-color: currentColor;}
+    // Selection wrapper.
+    // ------------------------------------------------------
+    &__selection-wrap {
+      position: relative;
+      display: inline-flex;
+      flex: 1 1 auto;
+      align-items: center;
+      min-height: $form-field-height; // Min-height to allow multiple lines.
+      border-radius: $border-radius;
+      border: $border;
+      transition: border $transition-duration;
 
-    // Underline.
-    &--underline:after {
-      content: '';
-      position: absolute;
-      bottom: -1px;
-      left: 0;
+      &--tile {border-radius: initial;}
+      &--shadow {box-shadow: $box-shadow;}
+      .w-select[class^="bdrs"] &, .w-select[class*=" bdrs"] & {border-radius: inherit;}
+
+      .w-select--floating-label & {margin-top: 3 * $base-increment;}
+
+      &--underline {
+        border-bottom-left-radius: initial;
+        border-bottom-right-radius: initial;
+        border-width: 0 0 1px;
+      }
+
+      &--round {border-radius: 99em;}
+
+      .w-select--focused &, .w-select--open & {border-color: currentColor;}
+
+      // Underline.
+      &--underline:after {
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 100%;
+        height: 0;
+        border-bottom: 2px solid currentColor;
+        transition: $transition-duration;
+        transform: scaleX(0);
+        pointer-events: none;
+      }
+
+      .w-select--focused &--underline:after,
+      .w-select--open &--underline:after {transform: scaleX(1);}
+      &--round.w-select__selection-wrap--underline:after {
+        border-radius: 99em;
+        transition: $transition-duration, height 0.035s;
+      }
+      .w-select--focused &--round.w-select__selection-wrap--underline:after,
+      .w-select--open &--round.w-select__selection-wrap--underline:after {
+        height: 100%;
+        transition: $transition-duration, height 0s ($transition-duration - 0.035s);
+      }
+    }
+
+    // Selection (contenteditable) field.
+    // Using contenteditable instead of readonly input in order to be able to fit to content.
+    // Then disable typing and hide caret.
+    // ------------------------------------------------------
+    &__selection {
       width: 100%;
-      height: 0;
-      border-bottom: 2px solid currentColor;
-      transition: $transition-duration;
-      transform: scaleX(0);
+      height: 100%;
+      min-height: inherit;
+      outline: none;
+      padding-left: 2 * $base-increment;
+      padding-right: 2 * $base-increment;
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      caret-color: transparent;
+      border-radius: inherit;
+
+      &--placeholder {color: #888;}
+
+      .w-select__selection-slot + & {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .w-select--no-padding & {
+        padding-left: 0;
+        padding-right: 0;
+      }
+
+      .w-select__selection-wrap--round & {
+        padding-left: 3 * $base-increment;
+        padding-right: 3 * $base-increment;
+      }
+
+      .w-select--inner-icon-left & {padding-left: 27px;}
+      &-slot, .w-select--inner-icon-right & {padding-right: 22px;}
+
+      .w-select--disabled & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      .w-select--readonly & {cursor: auto;}
+    }
+
+    &__selection-slot {
+      z-index: 1;
       pointer-events: none;
     }
 
-    .w-select--focused &--underline:after,
-    .w-select--open &--underline:after {transform: scaleX(1);}
-    &--round.w-select__selection-wrap--underline:after {
-      border-radius: 99em;
-      transition: $transition-duration, height 0.035s;
-    }
-    .w-select--focused &--round.w-select__selection-wrap--underline:after,
-    .w-select--open &--round.w-select__selection-wrap--underline:after {
-      height: 100%;
-      transition: $transition-duration, height 0s ($transition-duration - 0.035s);
-    }
-  }
-
-  // Selection (contenteditable) field.
-  // Using contenteditable instead of readonly input in order to be able to fit to content.
-  // Then disable typing and hide caret.
-  // ------------------------------------------------------
-  &__selection {
-    width: 100%;
-    height: 100%;
-    min-height: inherit;
-    outline: none;
-    padding-left: 2 * $base-increment;
-    padding-right: 2 * $base-increment;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    caret-color: transparent;
-    border-radius: inherit;
-
-    &--placeholder {color: #888;}
-
-    .w-select__selection-slot + & {
+    // Icons inside.
+    // ------------------------------------------------------
+    &__icon {
       position: absolute;
-      top: 0;
-      left: 0;
-    }
-    .w-select--no-padding & {
-      padding-left: 0;
-      padding-right: 0;
-    }
+      font-size: 1.4em;
+      cursor: pointer;
+      border-radius: 5em;
+      @include default-transition;
 
-    .w-select__selection-wrap--round & {
-      padding-left: 3 * $base-increment;
-      padding-right: 3 * $base-increment;
-    }
+      .w-select--focused &, .w-select--open & {color: currentColor;}
 
-    .w-select--inner-icon-left & {padding-left: 27px;}
-    &-slot, .w-select--inner-icon-right & {padding-right: 22px;}
+      .w-select--disabled &,
+      .w-select--readonly & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
 
-    .w-select--disabled & {
-      color: $disabled-color;
-      cursor: not-allowed;
-      -webkit-tap-highlight-color: transparent;
-    }
+      &--inner-left {left: $base-increment;}
+      &--inner-right {right: $base-increment;}
+      .w-select--no-padding &--inner-left {left: 1px;}
+      .w-select--no-padding &--inner-right {right: 1px;}
 
-    .w-select--readonly & {cursor: auto;}
-  }
+      .w-select--open &--inner-right {transform: rotate(180deg);}
 
-  &__selection-slot {
-    z-index: 1;
-    pointer-events: none;
-  }
-
-  // Icons inside.
-  // ------------------------------------------------------
-  &__icon {
-    position: absolute;
-    font-size: 1.4em;
-    cursor: pointer;
-    border-radius: 5em;
-    @include default-transition;
-
-    .w-select--focused &, .w-select--open & {color: currentColor;}
-
-    .w-select--disabled &,
-    .w-select--readonly & {
-      color: $disabled-color;
-      cursor: not-allowed;
-      -webkit-tap-highlight-color: transparent;
+      &:hover {background: rgba(0, 0, 0, 0.05);}
+      .w-select--disabled &:hover, .w-select--readonly &:hover {background-color: transparent;}
     }
 
-    &--inner-left {left: $base-increment;}
-    &--inner-right {right: $base-increment;}
-    .w-select--no-padding &--inner-left {left: 1px;}
-    .w-select--no-padding &--inner-right {right: 1px;}
+    // Label.
+    // ------------------------------------------------------
+    &__label {
+      display: flex;
+      align-items: center;
+      transition: color $transition-duration;
+      cursor: pointer;
+      user-select: none;
 
-    .w-select--open &--inner-right {transform: rotate(180deg);}
+      &--left {margin-right: 2 * $base-increment;}
+      &--right {margin-left: 2 * $base-increment;}
 
-    &:hover {background: rgba(0, 0, 0, 0.05);}
-    .w-select--disabled &:hover, .w-select--readonly &:hover {background-color: transparent;}
-  }
-
-  // Label.
-  // ------------------------------------------------------
-  &__label {
-    display: flex;
-    align-items: center;
-    transition: color $transition-duration;
-    cursor: pointer;
-    user-select: none;
-
-    &--left {margin-right: 2 * $base-increment;}
-    &--right {margin-left: 2 * $base-increment;}
-
-    .w-select--disabled & {
-      color: $disabled-color;
-      cursor: not-allowed;
-      -webkit-tap-highlight-color: transparent;
-    }
-    .w-select--readonly.w-select--empty & {
-      opacity: 0.5;
-      cursor: auto;
-    }
-  }
-
-  &__label--inside {
-    position: absolute;
-    inset: 0 0 auto;
-    min-height: inherit;
-    white-space: nowrap;
-    // Use margin instead of padding as the scale transformation below decreases the real padding
-    // size and misaligns the label.
-    margin-left: 2 * $base-increment;
-    pointer-events: none;
-
-    .w-select--inner-icon-right & {padding-right: 26px;}
-
-    .w-select--no-padding & {
-      left: 0;
-      margin-left: 0;
-    }
-    .w-select__selection-wrap--round & {
-      margin-left: round(3 * $base-increment);
-    }
-    .w-select--inner-icon-left & {left: 18px;}
-    .w-select--no-padding.w-select--inner-icon-left & {left: 26px;}
-
-    .w-select--floating-label & {
-      transform-origin: 0 0;
-      transition: $transition-duration ease;
+      .w-select--disabled & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .w-select--readonly.w-select--empty & {
+        opacity: 0.5;
+        cursor: auto;
+      }
     }
 
-    // Move label with underline style.
-    .w-select--open.w-select--floating-label &,
-    .w-select--filled.w-select--floating-label &,
-    .w-select--has-placeholder.w-select--floating-label & {
-      transform: translateY(-80%) scale(0.85);
-    }
-    // Chrome & Safari - Must stay a separated rule or Firefox discards the whole rule seeing -webkit-.
-    .w-select--floating-label .w-select__select:-webkit-autofill & {
-      transform: translateY(-80%) scale(0.85);
-    }
-    .w-select--open.w-select--floating-label.w-select--inner-icon-left &,
-    .w-select--filled.w-select--floating-label.w-select--inner-icon-left & {left: 0;}
-    // Chrome & Safari - Must stay a separated rule or Firefox discards the whole rule seeing -webkit-.
-    .w-select--floating-label.w-select--inner-icon-left .w-select__select:-webkit-autofill & {left: 0;}
-  }
+    &__label--inside {
+      position: absolute;
+      inset: 0 0 auto;
+      min-height: inherit;
+      white-space: nowrap;
+      // Use margin instead of padding as the scale transformation below decreases the real padding
+      // size and misaligns the label.
+      margin-left: 2 * $base-increment;
+      pointer-events: none;
 
-  // Menu.
-  // ------------------------------------------------------
-  &__menu {
-    margin: 0;
-    max-height: 300px;
-    overflow: auto;
-    background-color: $base-bg-color;
-    border: $border;
-    border-radius: $border-radius;
+      .w-select--inner-icon-right & {padding-right: 26px;}
 
-    .w-list {width: 100%;}
+      .w-select--no-padding & {
+        left: 0;
+        margin-left: 0;
+      }
+      .w-select__selection-wrap--round & {
+        margin-left: round(3 * $base-increment);
+      }
+      .w-select--inner-icon-left & {left: 18px;}
+      .w-select--no-padding.w-select--inner-icon-left & {left: 26px;}
+
+      .w-select--floating-label & {
+        transform-origin: 0 0;
+        transition: $transition-duration ease;
+      }
+
+      // Move label with underline style.
+      .w-select--open.w-select--floating-label &,
+      .w-select--filled.w-select--floating-label &,
+      .w-select--has-placeholder.w-select--floating-label & {
+        transform: translateY(-80%) scale(0.85);
+      }
+      // Chrome & Safari - Must stay a separated rule or Firefox discards the whole rule seeing -webkit-.
+      .w-select--floating-label .w-select__select:-webkit-autofill & {
+        transform: translateY(-80%) scale(0.85);
+      }
+      .w-select--open.w-select--floating-label.w-select--inner-icon-left &,
+      .w-select--filled.w-select--floating-label.w-select--inner-icon-left & {left: 0;}
+      // Chrome & Safari - Must stay a separated rule or Firefox discards the whole rule seeing -webkit-.
+      .w-select--floating-label.w-select--inner-icon-left .w-select__select:-webkit-autofill & {left: 0;}
+    }
+
+    // Menu.
+    // ------------------------------------------------------
+    &__menu {
+      margin: 0;
+      max-height: 300px;
+      overflow: auto;
+      background-color: $base-bg-color;
+      border: $border;
+      border-radius: $border-radius;
+
+      .w-list {width: 100%;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-slider.vue
+++ b/src/wave-ui/components/w-slider.vue
@@ -262,219 +262,221 @@ export default {
 </script>
 
 <style lang="scss">
-.w-slider {
-  position: relative;
-  display: flex;
-  align-items: center;
-  user-select: none;
-
-  @include themeable;
-
-  // Slider label, left & right.
-  // ------------------------------------------------------
-  &__label--left {margin-right: 3 * $base-increment;}
-  &__label--right {margin-left: 3 * $base-increment;}
-
-  // Steps labels.
-  // ------------------------------------------------------
-  &--has-step-labels {padding-bottom: 4 * $base-increment;}
-  &__step-labels {
-    position: absolute;
-    top: 0;
+#{$css-scope} {
+  .w-slider {
+    position: relative;
     display: flex;
-    width: 100%;
-  }
+    align-items: center;
+    user-select: none;
 
-  &__step-label {
-    position: absolute;
-    transform: translateX(-50%);
-    font-size: 0.8em;
-    padding-top: 2 * $base-increment;
-    color: $slider-step-label-color;
-    z-index: 1;
-    cursor: pointer;
+    @include themeable;
 
-    &:before {
-      content: '';
+    // Slider label, left & right.
+    // ------------------------------------------------------
+    &__label--left {margin-right: 3 * $base-increment;}
+    &__label--right {margin-left: 3 * $base-increment;}
+
+    // Steps labels.
+    // ------------------------------------------------------
+    &--has-step-labels {padding-bottom: 4 * $base-increment;}
+    &__step-labels {
       position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
       top: 0;
-      width: $base-increment;
-      aspect-ratio: 1;
-      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-      background-color: $slider-step-label-bg-color;
-      border-radius: 99em;
-      // box-shadow: 0 0 0 1px #fff;
-      box-sizing: border-box;
-      pointer-events: none;
-    }
-    &:first-child:before, &:last-child:before {display: none;}
-  }
-
-  // Track.
-  // ------------------------------------------------------
-  &__track-wrap {
-    position: relative;
-    flex-grow: 1;
-  }
-
-  &__track {
-    position: relative;
-    flex-grow: 1;
-    height: $slider-height;
-    background-color: $slider-track-color;
-    -webkit-tap-highlight-color: transparent;
-    border-radius: $border-radius;
-    touch-action: none;
-    cursor: pointer;
-
-    .w-slider--disabled &, .w-slider--readonly & {
-      cursor: not-allowed;
-      touch-action: initial;
+      display: flex;
+      width: 100%;
     }
 
-    &:before {
-      content: '';
+    &__step-label {
+      position: absolute;
+      transform: translateX(-50%);
+      font-size: 0.8em;
+      padding-top: 2 * $base-increment;
+      color: $slider-step-label-color;
+      z-index: 1;
+      cursor: pointer;
+
+      &:before {
+        content: '';
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        top: 0;
+        width: $base-increment;
+        aspect-ratio: 1;
+        min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+        background-color: $slider-step-label-bg-color;
+        border-radius: 99em;
+        // box-shadow: 0 0 0 1px #fff;
+        box-sizing: border-box;
+        pointer-events: none;
+      }
+      &:first-child:before, &:last-child:before {display: none;}
+    }
+
+    // Track.
+    // ------------------------------------------------------
+    &__track-wrap {
+      position: relative;
+      flex-grow: 1;
+    }
+
+    &__track {
+      position: relative;
+      flex-grow: 1;
+      height: $slider-height;
+      background-color: $slider-track-color;
+      -webkit-tap-highlight-color: transparent;
+      border-radius: $border-radius;
+      touch-action: none;
+      cursor: pointer;
+
+      .w-slider--disabled &, .w-slider--readonly & {
+        cursor: not-allowed;
+        touch-action: initial;
+      }
+
+      &:before {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        // For fat fingers.
+        top: -8px;
+        bottom: -8px;
+      }
+    }
+
+    // Range.
+    // ------------------------------------------------------
+    &__range {
       position: absolute;
       left: 0;
       right: 0;
-      // For fat fingers.
-      top: -8px;
-      bottom: -8px;
-    }
-  }
-
-  // Range.
-  // ------------------------------------------------------
-  &__range {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 100%;
-    z-index: 1;
-    transition: $transition-duration;
-    border-radius: inherit;
-
-    .w-slider--dragging & {transition: none;}
-    .w-slider--disabled & {opacity: 0.35;}
-  }
-
-  // Thumb.
-  // ------------------------------------------------------
-  &__thumb {
-    position: absolute;
-    width: 3 * $base-increment;
-    aspect-ratio: 1;
-    min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-    left: 100%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 2;
-    transition: $transition-duration;
-
-    .w-slider--dragging & {transition: none;}
-  }
-
-  &__thumb-button {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    aspect-ratio: 1;
-    min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-    border: none;
-    border-radius: 99em;
-    cursor: pointer;
-    background-color: $slider-thumb-button-bg-color;
-
-    .w-slider--disabled &, .w-slider--readonly & {cursor: auto;}
-
-    &:before, &:after {
-      content: '';
-      position: absolute;
+      height: 100%;
+      z-index: 1;
+      transition: $transition-duration;
       border-radius: inherit;
-      @include default-transition;
-    }
-    // Colored border on thumb when hover and active - but with a transparency.
-    &:before {
-      inset: 0;
-      opacity: 0.5;
-      border: 1px solid currentColor;
-    }
-    &:hover:before, &:focus:before {opacity: 0.7;}
-    &:active:before, .w-slider--dragging &:before {
-      opacity: 1;
-      box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
-      transition-duration: $fast-transition-duration;
-    }
-    .w-slider--disabled &:before,
-    .w-slider--readonly &:before {box-shadow: none;opacity: 0.4;}
 
-    // The outline when focused, but also a bigger reactive zone for fat fingers when not.
-    &:after {
-      left: -2 * $base-increment;
-      right: -2 * $base-increment;
-      top: -2 * $base-increment;
-      bottom: -2 * $base-increment;
-      opacity: 0;
-      background-color: currentColor;
+      .w-slider--dragging & {transition: none;}
+      .w-slider--disabled & {opacity: 0.35;}
     }
-    &:focus:after {opacity: 0.15;}
-    .w-slider--dragging &:after, &:active:after {opacity: 0.1;transform: scale(1.2);}
-  }
 
-  // Thumb label.
-  // ------------------------------------------------------
-  &__thumb-label {
-    position: absolute;
-    left: 50%;
-    bottom: 100%;
-    margin-bottom: round(3 * $base-increment);
-    transform: translateX(-50%);
-    padding: round(0.75 * $base-increment) (2 * $base-increment);
-    background-color: $slider-thumb-label-bg-color;
-    border-radius: $border-radius;
-    border: $border;
-    box-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
-    font-size: 0.85em;
-    color: $slider-thumb-label-color;
-
-    &:before, &:after {
-      content: '';
+    // Thumb.
+    // ------------------------------------------------------
+    &__thumb {
       position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 0;
-      height: 0;
-      border: solid transparent;
-    }
-
-    &:before {border-width: 7px;border-top-color: inherit;}
-    &:after {border-width: 6px;border-top-color: $slider-thumb-label-bg-color;}
-
-    &--droplet {
-      transform: translateX(-50%) rotate(-45deg);
-      border-radius: 99em 99em 99em 0;
-      width: 2.8em;
+      width: 3 * $base-increment;
       aspect-ratio: 1;
       min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+      left: 100%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      z-index: 2;
+      transition: $transition-duration;
 
-      & > div {
+      .w-slider--dragging & {transition: none;}
+    }
+
+    &__thumb-button {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      aspect-ratio: 1;
+      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+      border: none;
+      border-radius: 99em;
+      cursor: pointer;
+      background-color: $slider-thumb-button-bg-color;
+
+      .w-slider--disabled &, .w-slider--readonly & {cursor: auto;}
+
+      &:before, &:after {
+        content: '';
         position: absolute;
-        width: 100%;
-        height: 100%;
-        left: 0;
-        top: 0;
-        transform: rotate(45deg);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 1em;
+        border-radius: inherit;
+        @include default-transition;
+      }
+      // Colored border on thumb when hover and active - but with a transparency.
+      &:before {
+        inset: 0;
+        opacity: 0.5;
+        border: 1px solid currentColor;
+      }
+      &:hover:before, &:focus:before {opacity: 0.7;}
+      &:active:before, .w-slider--dragging &:before {
+        opacity: 1;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
+        transition-duration: $fast-transition-duration;
+      }
+      .w-slider--disabled &:before,
+      .w-slider--readonly &:before {box-shadow: none;opacity: 0.4;}
+
+      // The outline when focused, but also a bigger reactive zone for fat fingers when not.
+      &:after {
+        left: -2 * $base-increment;
+        right: -2 * $base-increment;
+        top: -2 * $base-increment;
+        bottom: -2 * $base-increment;
+        opacity: 0;
+        background-color: currentColor;
+      }
+      &:focus:after {opacity: 0.15;}
+      .w-slider--dragging &:after, &:active:after {opacity: 0.1;transform: scale(1.2);}
+    }
+
+    // Thumb label.
+    // ------------------------------------------------------
+    &__thumb-label {
+      position: absolute;
+      left: 50%;
+      bottom: 100%;
+      margin-bottom: round(3 * $base-increment);
+      transform: translateX(-50%);
+      padding: round(0.75 * $base-increment) (2 * $base-increment);
+      background-color: $slider-thumb-label-bg-color;
+      border-radius: $border-radius;
+      border: $border;
+      box-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
+      font-size: 0.85em;
+      color: $slider-thumb-label-color;
+
+      &:before, &:after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 0;
+        height: 0;
+        border: solid transparent;
       }
 
-      &:before, &:after {display: none;}
+      &:before {border-width: 7px;border-top-color: inherit;}
+      &:after {border-width: 6px;border-top-color: $slider-thumb-label-bg-color;}
+
+      &--droplet {
+        transform: translateX(-50%) rotate(-45deg);
+        border-radius: 99em 99em 99em 0;
+        width: 2.8em;
+        aspect-ratio: 1;
+        min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+
+        & > div {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          left: 0;
+          top: 0;
+          transform: rotate(45deg);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 1em;
+        }
+
+        &:before, &:after {display: none;}
+      }
     }
   }
 }

--- a/src/wave-ui/components/w-slideshow.vue
+++ b/src/wave-ui/components/w-slideshow.vue
@@ -22,6 +22,8 @@ export default {
 </script>
 
 <style lang="scss">
-.w-slideshow {
+#{$css-scope} {
+  .w-slideshow {
+  }
 }
 </style>

--- a/src/wave-ui/components/w-spinner.vue
+++ b/src/wave-ui/components/w-spinner.vue
@@ -55,86 +55,88 @@ export default {
 </script>
 
 <style lang="scss">
-.w-spinner {
-  position: relative;
-  display: inline-flex;
-  align-self: center;
-  font-size: 2rem;
-  width: 1em;
-  aspect-ratio: 1;
-  min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-
-  &.size--xs {font-size: round(0.9 * divide($base-font-size, 2)) * 2;}
-  &.size--sm {font-size: round(1.5 * $base-font-size);}
-  &.size--md {font-size: round(2 * $base-font-size);}
-  &.size--lg {font-size: round(2.5 * $base-font-size);}
-  &.size--xl {font-size: 3 * $base-font-size;}
-
-  &:before, &:after {
-    content: '';
-    position: absolute;
-    width: 100%;
+#{$css-scope} {
+  .w-spinner {
+    position: relative;
+    display: inline-flex;
+    align-self: center;
+    font-size: 2rem;
+    width: 1em;
     aspect-ratio: 1;
     min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-    top: 0;
-    left: 0;
-    background-color: currentColor;
-    border-radius: 100%;
-  }
 
-  &--bounce {
+    &.size--xs {font-size: round(0.9 * divide($base-font-size, 2)) * 2;}
+    &.size--sm {font-size: round(1.5 * $base-font-size);}
+    &.size--md {font-size: round(2 * $base-font-size);}
+    &.size--lg {font-size: round(2.5 * $base-font-size);}
+    &.size--xl {font-size: 3 * $base-font-size;}
+
     &:before, &:after {
-      opacity: 0.6;
-      animation: w-spinner-bounce 2s ease-in-out infinite;
-    }
-
-    &:after {animation-delay: -1.0s;}
-
-    @keyframes w-spinner-bounce {
-      0%, 100% {transform: scale(0);}
-      50% {transform: scale(1);}
-    }
-  }
-
-  &--fade {
-    &:before {animation: w-spinner-fade 1.5s ease-in-out infinite;}
-    &:after {display: none;}
-
-    @keyframes w-spinner-fade {
-      0% {transform: scale(0);}
-      100% {transform: scale(1);opacity: 0;}
-    }
-  }
-
-  &--three-dots {
-    position: relative;
-    width: 3.8em;
-    font-size: 1.3rem;
-
-    &:before, span, &:after {
-      width: 1em;
-      background: radial-gradient(circle at 50%, currentColor 70%, transparent 70.5%);
-      transform: scale(0);
-      animation: w-spinner-three-dots 1.2s 0s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite alternate;
-    }
-
-    span {
+      content: '';
       position: absolute;
-      left: 50%;
-      height: 1em;
-      margin-left: -0.5em;
-      animation-delay: 0.333s;
+      width: 100%;
+      aspect-ratio: 1;
+      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+      top: 0;
+      left: 0;
+      background-color: currentColor;
+      border-radius: 100%;
     }
 
-    &:after {
-      right: 0;
-      left: auto;
-      animation-delay: 0.666s;
+    &--bounce {
+      &:before, &:after {
+        opacity: 0.6;
+        animation: w-spinner-bounce 2s ease-in-out infinite;
+      }
+
+      &:after {animation-delay: -1.0s;}
+
+      @keyframes w-spinner-bounce {
+        0%, 100% {transform: scale(0);}
+        50% {transform: scale(1);}
+      }
     }
 
-    @keyframes w-spinner-three-dots {
-      0%, 40% {transform: scale(0);opacity: 0;}
-      100% {transform: scale(1);opacity: 1;}
+    &--fade {
+      &:before {animation: w-spinner-fade 1.5s ease-in-out infinite;}
+      &:after {display: none;}
+
+      @keyframes w-spinner-fade {
+        0% {transform: scale(0);}
+        100% {transform: scale(1);opacity: 0;}
+      }
+    }
+
+    &--three-dots {
+      position: relative;
+      width: 3.8em;
+      font-size: 1.3rem;
+
+      &:before, span, &:after {
+        width: 1em;
+        background: radial-gradient(circle at 50%, currentColor 70%, transparent 70.5%);
+        transform: scale(0);
+        animation: w-spinner-three-dots 1.2s 0s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite alternate;
+      }
+
+      span {
+        position: absolute;
+        left: 50%;
+        height: 1em;
+        margin-left: -0.5em;
+        animation-delay: 0.333s;
+      }
+
+      &:after {
+        right: 0;
+        left: auto;
+        animation-delay: 0.666s;
+      }
+
+      @keyframes w-spinner-three-dots {
+        0%, 40% {transform: scale(0);opacity: 0;}
+        100% {transform: scale(1);opacity: 1;}
+      }
     }
   }
 }

--- a/src/wave-ui/components/w-steps.vue
+++ b/src/wave-ui/components/w-steps.vue
@@ -28,7 +28,9 @@ export default {
 </script>
 
 <style lang="scss">
-.w-steps {
-  @include themeable;
+#{$css-scope} {
+  .w-steps {
+    @include themeable;
+  }
 }
 </style>

--- a/src/wave-ui/components/w-switch.vue
+++ b/src/wave-ui/components/w-switch.vue
@@ -145,164 +145,166 @@ export default {
 <style lang="scss">
 $outline-width: 2px;
 
-.w-switch {
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-  cursor: pointer;
-
-  @include themeable;
-
-  &--loading {cursor: wait;}
-  &--disabled, &--readonly {
-    cursor: not-allowed;
-    touch-action: initial;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  // Hidden checkbox.
-  input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    z-index: -100;
-    outline: none;
-  }
-
-  // Switch.
-  &__input {
-    position: relative;
-    width: 2 * ($small-form-el-size + $outline-width);
-    height: $small-form-el-size + (2 * $outline-width);
-    display: flex;
-    flex: 0 0 auto; // Prevent stretching width or height.
+#{$css-scope} {
+  .w-switch {
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    border: $outline-width solid transparent;
-    border-radius: 3em;
-    background-color: $switch-inactive-color;
-    cursor: inherit;
-    @include default-transition;
+    vertical-align: middle;
+    cursor: pointer;
 
-    .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
+    @include themeable;
 
-    // Checked state.
-    :checked ~ & {
-      border-color: currentColor;
+    &--loading {cursor: wait;}
+    &--disabled, &--readonly {
+      cursor: not-allowed;
+      touch-action: initial;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    // Hidden checkbox.
+    input[type="checkbox"] {
+      position: absolute;
+      opacity: 0;
+      z-index: -100;
+      outline: none;
+    }
+
+    // Switch.
+    &__input {
+      position: relative;
+      width: 2 * ($small-form-el-size + $outline-width);
+      height: $small-form-el-size + (2 * $outline-width);
+      display: flex;
+      flex: 0 0 auto; // Prevent stretching width or height.
+      align-items: center;
+      justify-content: center;
+      border: $outline-width solid transparent;
+      border-radius: 3em;
+      background-color: $switch-inactive-color;
+      cursor: inherit;
+      @include default-transition;
+
+      .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
+
+      // Checked state.
+      :checked ~ & {
+        border-color: currentColor;
+        background-color: currentColor;
+      }
+
+      // Thin.
+      .w-switch--thin & {
+        box-sizing: border-box;
+        border: none;
+        width: 2 * $small-form-el-size;
+        height: round(0.7 * $small-form-el-size);
+      }
+      .w-switch--thin :checked ~ & {background-color: $switch-inactive-color;}
+
+      // Disabled.
+      .w-switch--disabled & {color: $disabled-color;}
+      .w-switch--disabled :checked ~ & {opacity: 0.5;}
+    }
+
+    // Track slot, if any.
+    &__track {
+      position: absolute;
+      left: 100%;
+      padding: 0 4px;
+      transform: translateX(-100%);
+      @include default-transition;
+    }
+    .w-switch--on &__track {left: 0;transform: translateX(0);}
+
+    // Thumb: show either the thumb slot if any, or :after otherwise.
+    &__thumb, &__input:after {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: $small-form-el-size;
+      height: $small-form-el-size;
+      background-color: $switch-thumb-color;
+      border-radius: 100%;
+      text-align: center;
+      @include default-transition;
+
+      .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
+
+      .w-switch--on & {left: 100%;transform: translateX(-100%);}
+
+      .w-switch--thin & {
+        top: - round(0.15 * $small-form-el-size);
+        transform: scale(1.1);
+        box-shadow: $box-shadow;
+      }
+      .w-switch--thin.w-switch--on & {
+        transform: translateX(-100%) scale(1.1);
+        background-color: currentColor;
+      }
+    }
+    &--loading .w-progress {padding: 1px;}
+    &--loading.w-switch--thin.w-switch--on .w-progress {color: #fff;}
+    &--loading &__input:after, &--custom-thumb &__input:after {display: none;}
+    &__thumb > * {
+      width: inherit;
+      height: inherit;
+    }
+
+    // The focus outline & ripple on switch activation.
+    &__input:before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: $small-form-el-size;
+      aspect-ratio: 1;
       background-color: currentColor;
+      border-radius: 100%;
+      opacity: 0;
+      pointer-events: none;
+      transition: 0.25s ease-in-out;
+
+      :checked ~ & {transform: translateX(-100%) scale(0);left: 100%;}
+
+      .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
+      .w-switch--thin & {top: - round(0.15 * $small-form-el-size);}
     }
 
-    // Thin.
-    .w-switch--thin & {
-      box-sizing: border-box;
-      border: none;
-      width: 2 * $small-form-el-size;
-      height: round(0.7 * $small-form-el-size);
+    &--ripple &__input:before {
+      background-color: transparent;
+      animation: w-switch-ripple 0.55s 0.15s ease;
     }
-    .w-switch--thin :checked ~ & {background-color: $switch-inactive-color;}
 
-    // Disabled.
-    .w-switch--disabled & {color: $disabled-color;}
-    .w-switch--disabled :checked ~ & {opacity: 0.5;}
-  }
-
-  // Track slot, if any.
-  &__track {
-    position: absolute;
-    left: 100%;
-    padding: 0 4px;
-    transform: translateX(-100%);
-    @include default-transition;
-  }
-  .w-switch--on &__track {left: 0;transform: translateX(0);}
-
-  // Thumb: show either the thumb slot if any, or :after otherwise.
-  &__thumb, &__input:after {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: $small-form-el-size;
-    height: $small-form-el-size;
-    background-color: $switch-thumb-color;
-    border-radius: 100%;
-    text-align: center;
-    @include default-transition;
-
-    .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
-
-    .w-switch--on & {left: 100%;transform: translateX(-100%);}
-
-    .w-switch--thin & {
-      top: - round(0.15 * $small-form-el-size);
-      transform: scale(1.1);
-      box-shadow: $box-shadow;
+    :focus ~ &__input:before {
+      transform: translateX(0) scale(1.8);
+      opacity: 0.2;
     }
-    .w-switch--thin.w-switch--on & {
-      transform: translateX(-100%) scale(1.1);
-      background-color: currentColor;
+    :focus:checked ~ &__input:before {
+      transform: translateX(-100%) scale(1.8);
+    }
+
+    // After ripple reset to default state, then remove the class via js and the
+    // `:focus ~ &__input:before` will re-transition to normal focused outline.
+    &--rippled &__input:before {
+      transition: none;
+      transform: translateX(-100%) scale(0);
+      opacity: 0;
+    }
+
+    &__label {
+      display: flex;
+      align-items: center;
+      cursor: inherit;
+      user-select: none;
+
+      .w-switch--disabled & {opacity: 0.5;}
     }
   }
-  &--loading .w-progress {padding: 1px;}
-  &--loading.w-switch--thin.w-switch--on .w-progress {color: #fff;}
-  &--loading &__input:after, &--custom-thumb &__input:after {display: none;}
-  &__thumb > * {
-    width: inherit;
-    height: inherit;
+
+  @keyframes w-switch-ripple {
+    0% {opacity: 0.8;transform: translateX(-100%) scale(1);background-color: currentColor;} // Start with visible ripple.
+    100% {opacity: 0;transform: translateX(-100%) scale(2.8);} // Propagate ripple to max radius and fade out.
   }
-
-  // The focus outline & ripple on switch activation.
-  &__input:before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: $small-form-el-size;
-    aspect-ratio: 1;
-    background-color: currentColor;
-    border-radius: 100%;
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.25s ease-in-out;
-
-    :checked ~ & {transform: translateX(-100%) scale(0);left: 100%;}
-
-    .w-switch[class^="bdrs"] &, .w-switch[class*=" bdrs"] & {border-radius: inherit;}
-    .w-switch--thin & {top: - round(0.15 * $small-form-el-size);}
-  }
-
-  &--ripple &__input:before {
-    background-color: transparent;
-    animation: w-switch-ripple 0.55s 0.15s ease;
-  }
-
-  :focus ~ &__input:before {
-    transform: translateX(0) scale(1.8);
-    opacity: 0.2;
-  }
-  :focus:checked ~ &__input:before {
-    transform: translateX(-100%) scale(1.8);
-  }
-
-  // After ripple reset to default state, then remove the class via js and the
-  // `:focus ~ &__input:before` will re-transition to normal focused outline.
-  &--rippled &__input:before {
-    transition: none;
-    transform: translateX(-100%) scale(0);
-    opacity: 0;
-  }
-
-  &__label {
-    display: flex;
-    align-items: center;
-    cursor: inherit;
-    user-select: none;
-
-    .w-switch--disabled & {opacity: 0.5;}
-  }
-}
-
-@keyframes w-switch-ripple {
-  0% {opacity: 0.8;transform: translateX(-100%) scale(1);background-color: currentColor;} // Start with visible ripple.
-  100% {opacity: 0;transform: translateX(-100%) scale(2.8);} // Propagate ripple to max radius and fade out.
 }
 </style>

--- a/src/wave-ui/components/w-table.vue
+++ b/src/wave-ui/components/w-table.vue
@@ -707,323 +707,325 @@ export default {
 <style lang="scss">
 $tr-border-top: 1px;
 
-.w-table {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  border-radius: $border-radius;
-  border: $border;
+#{$css-scope} {
+  .w-table {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    border-radius: $border-radius;
+    border: $border;
 
-  &--loading {overflow: hidden;}
+    &--loading {overflow: hidden;}
 
-  &--resizing {
-    user-select: none;
+    &--resizing {
+      user-select: none;
 
-    &, * {cursor: col-resize;}
-  }
+      &, * {cursor: col-resize;}
+    }
 
-  &__scroll-wrap {
-    overflow: auto;
-    min-height: 100%;
-  }
+    &__scroll-wrap {
+      overflow: auto;
+      min-height: 100%;
+    }
 
-  &__table {
-    width: 100%;
-    min-height: 100%;
-    border-collapse: collapse;
-    border: none;
+    &__table {
+      width: 100%;
+      min-height: 100%;
+      border-collapse: collapse;
+      border: none;
 
-    @include themeable;
+      @include themeable;
 
-    &--fixed-layout & {table-layout: fixed;} // Allow resizing beyond the cell minimum text width.
-  }
+      &--fixed-layout & {table-layout: fixed;} // Allow resizing beyond the cell minimum text width.
+    }
 
-  // Table columns.
-  // ------------------------------------------------------
-  &__col--highlighted {
-    background-color: rgba(var(--w-contrast-bg-color-rgb), 0.04);
-  }
+    // Table columns.
+    // ------------------------------------------------------
+    &__col--highlighted {
+      background-color: rgba(var(--w-contrast-bg-color-rgb), 0.04);
+    }
 
-  // Table headers.
-  // ------------------------------------------------------
-  thead {position: relative;}
+    // Table headers.
+    // ------------------------------------------------------
+    thead {position: relative;}
 
-  &__header {padding: $base-increment;}
-  &__header--resizable {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
+    &__header {padding: $base-increment;}
+    &__header--resizable {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
 
-  &--fixed-header thead {
-    position: sticky;
-    top: 0;
-    background-color: $base-bg-color;
-    z-index: 1; // For sticky columns to go under.
+    &--fixed-header thead {
+      position: sticky;
+      top: 0;
+      background-color: $base-bg-color;
+      z-index: 1; // For sticky columns to go under.
 
-    &:after {
-      content: '';
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-bottom: $border;
+      }
+    }
+
+    &__header--sticky {
+      position: sticky;
+      left: 0;
+
+      &:before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        background-color: $base-bg-color;
+      }
+    }
+
+    // Sorting arrow.
+    &__header--sortable {cursor: pointer;}
+    &__header-sort {
+      color: rgba(var(--w-base-color-rgb), 0.8);
+      vertical-align: text-bottom;
+      @include default-transition;
+
+      &--asc {transform: rotate(180deg);}
+      &--desc {transform: rotate(0deg);}
+      &--inactive {opacity: 0;}
+      th:hover &--inactive {opacity: 0.5;}
+      th:hover &--active {opacity: 1;}
+      &--active {opacity: 0.7;}
+    }
+
+    // Resizable columns.
+    &__header--resizable {position: relative;}
+    &__col-resizer {
+      position: absolute;
+      right: -5px;
+      top: -$tr-border-top;
+      bottom: 0;
+      width: 10px;
+      cursor: col-resize;
+      z-index: 1;
+
+      &:before {
+        content: '';
+        border-right: $border;
+        position: absolute;
+        left: 50%;
+        top: 0;
+        bottom: 0;
+        transform: translateX(-50%);
+      }
+      &--hover:before, &--active:before {border-right-width: 2px;}
+    }
+
+    // Progress bar when loading.
+    &__progress-bar:nth-child(odd) {background: none;}
+    thead .w-progress {
       position: absolute;
       bottom: 0;
       left: 0;
       right: 0;
-      border-bottom: $border;
     }
-  }
+    &__progress-bar td {padding: 0;height: 0;}
+    @-moz-document url-prefix() {
+      &__progress-bar td {height: 100%;}
+    }
 
-  &__header--sticky {
-    position: sticky;
-    left: 0;
+    &__loading-text {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      width: 100%;
+      padding-top: 2 * $base-increment;
+      padding-bottom: 2 * $base-increment;
+    }
 
-    &:before {
+    // Table body.
+    // ------------------------------------------------------
+    tbody {transition: opacity $transition-duration;}
+    &--loading-in-header tbody {opacity: 0.6;}
+
+    tbody tr {border-top: $tr-border-top solid rgba(var(--w-base-color-rgb), 0.06);}
+    // Don't apply built-in bg color if a bg color is already found on a tr.
+    tbody tr:nth-child(odd):not(.no-data):not([class*="--bg"]) {background-color: $table-tr-odd-color;}
+    tbody .w-table__row:hover:not(.no-data):not([class*="--bg"]) {background-color: $table-tr-hover-color;}
+
+    &__row--selected td {position: relative;}
+    &__row--selected td:before {
       content: '';
       position: absolute;
       inset: 0;
-      z-index: -1;
+      background-color: var(--w-primary-color);
+      opacity: 0.2;
+      pointer-events: none;
+    }
+
+    &__cell {padding: round(divide($base-increment, 2)) $base-increment;}
+    &__header:first-child, &__cell:first-child {padding-left: 2 * $base-increment;}
+    &__header:last-child, &__cell:last-child {padding-right: 2 * $base-increment;}
+
+    &--resizable-cols &__cell {
+      position: relative;
+
+      &, & * {
+        overflow: hidden;
+        // white-space: nowrap; // If you only want the content cell on a single line.
+        text-overflow: ellipsis;
+      }
+    }
+
+    &__cell--sticky {
+      position: sticky;
+      left: 0;
+
+      &:before, &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: -1;
+      }
+      &:before {background-color: $base-bg-color;}
+    }
+    tr:nth-child(odd) &__cell--sticky:after {background-color: $table-tr-odd-color;}
+    tr:hover &__cell--sticky:after {background-color: $table-tr-hover-color;}
+
+    .no-data &__cell {
+      background-color: rgba(255, 255, 255, 0.2);
+      padding: (2 * $base-increment) $base-increment;
+    }
+
+    // Table footer.
+    // ------------------------------------------------------
+    &--fixed-footer tfoot {
+      position: sticky;
+      bottom: -1px;
       background-color: $base-bg-color;
-    }
-  }
+      z-index: 1; // For sticky columns to go under.
 
-  // Sorting arrow.
-  &__header--sortable {cursor: pointer;}
-  &__header-sort {
-    color: rgba(var(--w-base-color-rgb), 0.8);
-    vertical-align: text-bottom;
-    @include default-transition;
-
-    &--asc {transform: rotate(180deg);}
-    &--desc {transform: rotate(0deg);}
-    &--inactive {opacity: 0;}
-    th:hover &--inactive {opacity: 0.5;}
-    th:hover &--active {opacity: 1;}
-    &--active {opacity: 0.7;}
-  }
-
-  // Resizable columns.
-  &__header--resizable {position: relative;}
-  &__col-resizer {
-    position: absolute;
-    right: -5px;
-    top: -$tr-border-top;
-    bottom: 0;
-    width: 10px;
-    cursor: col-resize;
-    z-index: 1;
-
-    &:before {
-      content: '';
-      border-right: $border;
-      position: absolute;
-      left: 50%;
-      top: 0;
-      bottom: 0;
-      transform: translateX(-50%);
-    }
-    &--hover:before, &--active:before {border-right-width: 2px;}
-  }
-
-  // Progress bar when loading.
-  &__progress-bar:nth-child(odd) {background: none;}
-  thead .w-progress {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-  &__progress-bar td {padding: 0;height: 0;}
-  @-moz-document url-prefix() {
-    &__progress-bar td {height: 100%;}
-  }
-
-  &__loading-text {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    width: 100%;
-    padding-top: 2 * $base-increment;
-    padding-bottom: 2 * $base-increment;
-  }
-
-  // Table body.
-  // ------------------------------------------------------
-  tbody {transition: opacity $transition-duration;}
-  &--loading-in-header tbody {opacity: 0.6;}
-
-  tbody tr {border-top: $tr-border-top solid rgba(var(--w-base-color-rgb), 0.06);}
-  // Don't apply built-in bg color if a bg color is already found on a tr.
-  tbody tr:nth-child(odd):not(.no-data):not([class*="--bg"]) {background-color: $table-tr-odd-color;}
-  tbody .w-table__row:hover:not(.no-data):not([class*="--bg"]) {background-color: $table-tr-hover-color;}
-
-  &__row--selected td {position: relative;}
-  &__row--selected td:before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background-color: var(--w-primary-color);
-    opacity: 0.2;
-    pointer-events: none;
-  }
-
-  &__cell {padding: round(divide($base-increment, 2)) $base-increment;}
-  &__header:first-child, &__cell:first-child {padding-left: 2 * $base-increment;}
-  &__header:last-child, &__cell:last-child {padding-right: 2 * $base-increment;}
-
-  &--resizable-cols &__cell {
-    position: relative;
-
-    &, & * {
-      overflow: hidden;
-      // white-space: nowrap; // If you only want the content cell on a single line.
-      text-overflow: ellipsis;
-    }
-  }
-
-  &__cell--sticky {
-    position: sticky;
-    left: 0;
-
-    &:before, &:after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: -1;
-    }
-    &:before {background-color: $base-bg-color;}
-  }
-  tr:nth-child(odd) &__cell--sticky:after {background-color: $table-tr-odd-color;}
-  tr:hover &__cell--sticky:after {background-color: $table-tr-hover-color;}
-
-  .no-data &__cell {
-    background-color: rgba(255, 255, 255, 0.2);
-    padding: (2 * $base-increment) $base-increment;
-  }
-
-  // Table footer.
-  // ------------------------------------------------------
-  &--fixed-footer tfoot {
-    position: sticky;
-    bottom: -1px;
-    background-color: $base-bg-color;
-    z-index: 1; // For sticky columns to go under.
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      border-top: $border;
-    }
-  }
-
-  &__footer &__cell {
-    padding-top: $base-increment;
-    padding-bottom: $base-increment;
-  }
-
-  // Pagination.
-  // ------------------------------------------------------
-  &__pagination {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 2 * $base-increment;
-    padding: $base-increment 2 * $base-increment;
-
-    .w-pagination__items-per-page {
-      flex: 0 0 auto;
-      text-align: right;
+      &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        border-top: $border;
+      }
     }
 
-    .pages-wrap {
+    &__footer &__cell {
+      padding-top: $base-increment;
+      padding-bottom: $base-increment;
+    }
+
+    // Pagination.
+    // ------------------------------------------------------
+    &__pagination {
       display: flex;
-      padding-left: 1px; // Prevent overflow causing scrollbar.
-      padding-right: 1px;
-      max-height: 4.5em;
-      gap: 0.5 * $base-increment;
-      overflow-y: hidden;
-    }
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2 * $base-increment;
+      padding: $base-increment 2 * $base-increment;
 
-    .w-pagination__page {
-      font-size: 0.9em;
-      aspect-ratio: 1;
-      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-      overflow: hidden;
-      color: rgba(var(--w-base-color-rgb), 0.65);
-      background-color: rgba(var(--w-base-bg-color-rgb), 0.4);
-
-      &:hover:before {
-        background-color: $primary;
-        opacity: 0.1;
-      }
-      &:active:before {
-        background-color: $primary;
-        opacity: 0.2;
+      .w-pagination__items-per-page {
+        flex: 0 0 auto;
+        text-align: right;
       }
 
-      &--active {
-        font-weight: bold;
-        color: $primary;
+      .pages-wrap {
+        display: flex;
+        padding-left: 1px; // Prevent overflow causing scrollbar.
+        padding-right: 1px;
+        max-height: 4.5em;
+        gap: 0.5 * $base-increment;
+        overflow-y: hidden;
+      }
 
-        &:before {
+      .w-pagination__page {
+        font-size: 0.9em;
+        aspect-ratio: 1;
+        min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+        overflow: hidden;
+        color: rgba(var(--w-base-color-rgb), 0.65);
+        background-color: rgba(var(--w-base-bg-color-rgb), 0.4);
+
+        &:hover:before {
           background-color: $primary;
           opacity: 0.1;
         }
+        &:active:before {
+          background-color: $primary;
+          opacity: 0.2;
+        }
+
+        &--active {
+          font-weight: bold;
+          color: $primary;
+
+          &:before {
+            background-color: $primary;
+            opacity: 0.1;
+          }
+        }
+      }
+
+      .w-pagination__results {
+        white-space: nowrap;
+        text-align: right;
       }
     }
+  }
 
-    .w-pagination__results {
-      white-space: nowrap;
-      text-align: right;
+  // Mobile layout.
+  .w-table--mobile {
+    display: flex;
+
+    thead {display: none;}
+    tbody {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
     }
-  }
-}
+    tr {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      padding-top: $base-increment;
+      padding-bottom: $base-increment;
+    }
 
-// Mobile layout.
-.w-table--mobile {
-  display: flex;
+    .w-table__cell {
+      display: flex;
+      padding-left: 2 * $base-increment;
+      padding-right: 2 * $base-increment;
+    }
 
-  thead {display: none;}
-  tbody {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-  }
-  tr {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    padding-top: $base-increment;
-    padding-bottom: $base-increment;
-  }
+    tr:not(.no-data) .text-center,
+    tr:not(.no-data) .text-right {text-align: left;}
 
-  .w-table__cell {
-    display: flex;
-    padding-left: 2 * $base-increment;
-    padding-right: 2 * $base-increment;
-  }
+    .w-table__cell:before {
+      content: attr(data-label);
+      font-weight: bold;
+      width: 6.5em;
+      padding-right: 0.5em;
+      display: inline-flex;
+    }
+    .no-data .w-table__cell:before {display: none;}
 
-  tr:not(.no-data) .text-center,
-  tr:not(.no-data) .text-right {text-align: left;}
+    .w-table__progress-bar {
+      display: table-row;
 
-  .w-table__cell:before {
-    content: attr(data-label);
-    font-weight: bold;
-    width: 6.5em;
-    padding-right: 0.5em;
-    display: inline-flex;
-  }
-  .no-data .w-table__cell:before {display: none;}
-
-  .w-table__progress-bar {
-    display: table-row;
-
-    td {display: table-cell;}
-    td:before {display: none;}
+      td {display: table-cell;}
+      td:before {display: none;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-tabs/index.vue
+++ b/src/wave-ui/components/w-tabs/index.vue
@@ -342,152 +342,154 @@ export default {
 </script>
 
 <style lang="scss">
-.w-tabs {
-  z-index: 1;
-  border-radius: $border-radius;
-  border: $border;
-  overflow: hidden;
+#{$css-scope} {
+  .w-tabs {
+    z-index: 1;
+    border-radius: $border-radius;
+    border: $border;
+    overflow: hidden;
 
-  @include themeable;
+    @include themeable;
 
-  &--tile {border-radius: 0;}
-  &--card {border: none;}
-  &--no-border, &--shadow {border: none;}
+    &--tile {border-radius: 0;}
+    &--card {border: none;}
+    &--no-border, &--shadow {border: none;}
 
-  &__bar {
-    position: relative;
-    display: flex;
-    overflow-x: auto;
-
-    &--center {justify-content: center;}
-    &--right {justify-content: flex-end;}
-    .w-tabs--pill-slider & {padding-left: $base-increment;}
-
-    .w-tabs--card &:after {
-      content: '';
+    &__bar {
+      position: relative;
       display: flex;
-      flex-grow: 1;
-      border-bottom: $border;
-      align-self: flex-end;
+      overflow-x: auto;
+
+      &--center {justify-content: center;}
+      &--right {justify-content: flex-end;}
+      .w-tabs--pill-slider & {padding-left: $base-increment;}
+
+      .w-tabs--card &:after {
+        content: '';
+        display: flex;
+        flex-grow: 1;
+        border-bottom: $border;
+        align-self: flex-end;
+      }
     }
-  }
 
-  // Bar item.
-  // ------------------------------------------------------
-  &__bar-item {
-    position: relative;
-    display: flex;
-    align-items: center;
-    padding: (2 * $base-increment) (3 * $base-increment);
-    justify-content: center;
-    font-size: round(1.2 * $base-font-size);
-    transition: $transition-duration ease-in-out, flex-grow 0s, flex 0s; // `flex` for Safari.
-    user-select: none;
-    cursor: pointer;
-    -webkit-tap-highlight-color: transparent;
-
-    .w-tabs--fill-bar & {flex-grow: 1;flex-basis: 0;}
-    .w-tabs--card & {
-      border: $border;
-      border-radius: $border-radius $border-radius 0 0;
-      margin-right: -1px;
-    }
-    .w-tabs--card &--active {border-bottom-color: transparent;}
-
-    &--disabled {
-      cursor: not-allowed;
-      opacity: 0.6;
+    // Bar item.
+    // ------------------------------------------------------
+    &__bar-item {
+      position: relative;
+      display: flex;
+      align-items: center;
+      padding: (2 * $base-increment) (3 * $base-increment);
+      justify-content: center;
+      font-size: round(1.2 * $base-font-size);
+      transition: $transition-duration ease-in-out, flex-grow 0s, flex 0s; // `flex` for Safari.
+      user-select: none;
+      cursor: pointer;
       -webkit-tap-highlight-color: transparent;
+
+      .w-tabs--fill-bar & {flex-grow: 1;flex-basis: 0;}
+      .w-tabs--card & {
+        border: $border;
+        border-radius: $border-radius $border-radius 0 0;
+        margin-right: -1px;
+      }
+      .w-tabs--card &--active {border-bottom-color: transparent;}
+
+      &--disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      &:before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: currentColor;
+        opacity: 0;
+        transition: $fast-transition-duration;
+      }
+
+      &--active:before, &:focus:before, &:hover:before {opacity: 0.05;}
+      &:active:before {opacity: 0.08;}
+      &--disabled:before {display: none;}
+    }
+    &--pill-slider &__bar-item:before {display: none;}
+
+    // Bar Extra.
+    // ------------------------------------------------------
+    &__bar-extra {
+      margin-left: auto;
+      align-self: center;
+      position: sticky;
+      right: 0;
+
+      .w-tabs__bar--right &,
+      .w-tabs__bar--center & {margin-left: 0;}
     }
 
-    &:before {
-      content: '';
+    // Slider.
+    // ------------------------------------------------------
+    &__slider {
       position: absolute;
-      inset: 0;
+      bottom: 0;
+      height: 2px;
       background-color: currentColor;
-      opacity: 0;
-      transition: $fast-transition-duration;
+      transition: $transition-duration ease-in-out;
+    }
+    &--pill-slider &__slider {
+      opacity: 0.1;
+      bottom: 15%;
+      height: 70%;
+      border-radius: 99em;
     }
 
-    &--active:before, &:focus:before, &:hover:before {opacity: 0.05;}
-    &:active:before {opacity: 0.08;}
-    &--disabled:before {display: none;}
+    &--init &__slider {transition: none;}
+
+    // Content.
+    // ------------------------------------------------------
+    &__content-wrap {
+      position: relative;
+      flex-grow: 1;
+
+      .w-tabs--card & {
+        border: $border;
+        border-top: none;
+        border-radius: 0 0 $border-radius $border-radius;
+      }
+    }
+    &__content {padding: 3 * $base-increment;}
   }
-  &--pill-slider &__bar-item:before {display: none;}
 
-  // Bar Extra.
-  // ------------------------------------------------------
-  &__bar-extra {
-    margin-left: auto;
-    align-self: center;
-    position: sticky;
-    right: 0;
-
-    .w-tabs__bar--right &,
-    .w-tabs__bar--center & {margin-left: 0;}
-  }
-
-  // Slider.
-  // ------------------------------------------------------
-  &__slider {
+  .w-tabs-slide-left-leave-active,
+  .w-tabs-slide-right-leave-active {
     position: absolute;
-    bottom: 0;
-    height: 2px;
-    background-color: currentColor;
-    transition: $transition-duration ease-in-out;
-  }
-  &--pill-slider &__slider {
-    opacity: 0.1;
-    bottom: 15%;
-    height: 70%;
-    border-radius: 99em;
+    top: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
   }
 
-  &--init &__slider {transition: none;}
-
-  // Content.
-  // ------------------------------------------------------
-  &__content-wrap {
-    position: relative;
-    flex-grow: 1;
-
-    .w-tabs--card & {
-      border: $border;
-      border-top: none;
-      border-radius: 0 0 $border-radius $border-radius;
-    }
+  .w-tabs-slide-left-enter-active {animation: w-tabs-slide-left-enter $transition-duration + 0.15s;}
+  .w-tabs-slide-left-leave-active {animation: w-tabs-slide-left-leave $transition-duration + 0.15s;}
+  @keyframes w-tabs-slide-left-enter {
+    0% {transform: translateX(100%);}
+    100% {transform: translateX(0);}
   }
-  &__content {padding: 3 * $base-increment;}
-}
+  @keyframes w-tabs-slide-left-leave {
+    0% {transform: translateX(0);}
+    100% {transform: translateX(-100%);}
+  }
 
-.w-tabs-slide-left-leave-active,
-.w-tabs-slide-right-leave-active {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  overflow: hidden;
-}
-
-.w-tabs-slide-left-enter-active {animation: w-tabs-slide-left-enter $transition-duration + 0.15s;}
-.w-tabs-slide-left-leave-active {animation: w-tabs-slide-left-leave $transition-duration + 0.15s;}
-@keyframes w-tabs-slide-left-enter {
-  0% {transform: translateX(100%);}
-  100% {transform: translateX(0);}
-}
-@keyframes w-tabs-slide-left-leave {
-  0% {transform: translateX(0);}
-  100% {transform: translateX(-100%);}
-}
-
-.w-tabs-slide-right-enter-active {animation: w-tabs-slide-right-enter $transition-duration + 0.15s;}
-.w-tabs-slide-right-leave-active {animation: w-tabs-slide-right-leave $transition-duration + 0.15s;}
-@keyframes w-tabs-slide-right-enter {
-  0% {transform: translateX(-100%);}
-  100% {transform: translateX(0);}
-}
-@keyframes w-tabs-slide-right-leave {
-  0% {transform: translateX(0);}
-  100% {transform: translateX(100%);}
+  .w-tabs-slide-right-enter-active {animation: w-tabs-slide-right-enter $transition-duration + 0.15s;}
+  .w-tabs-slide-right-leave-active {animation: w-tabs-slide-right-leave $transition-duration + 0.15s;}
+  @keyframes w-tabs-slide-right-enter {
+    0% {transform: translateX(-100%);}
+    100% {transform: translateX(0);}
+  }
+  @keyframes w-tabs-slide-right-leave {
+    0% {transform: translateX(0);}
+    100% {transform: translateX(100%);}
+  }
 }
 </style>

--- a/src/wave-ui/components/w-tag.vue
+++ b/src/wave-ui/components/w-tag.vue
@@ -80,114 +80,116 @@ export default {
 </script>
 
 <style lang="scss">
-.w-tag {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-radius: $border-radius;
-  border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.08);
-  background-color: rgba(var(--w-base-bg-color-rgb), 0.85);
-  padding-left: 2 * $base-increment;
-  padding-right: 2 * $base-increment;
-  cursor: default;
-  user-select: none;
-
-  @include themeable;
-
-  &--dark {color: rgba(var(--w-base-bg-color-rgb), 0.95);}
-  &--outline {background-color: transparent;border-color: currentColor;}
-  &--no-border {border-color: transparent;}
-  &--round {border-radius: 99em;}
-  &--tile {border-radius: initial;}
-  &--shadow {box-shadow: $box-shadow;}
-
-  &.size--xs {
-    $font-size: round(0.7 * $base-font-size);
-    font-size: $font-size;
-    line-height: $font-size + 2px;
-    padding: round(0.25 * $base-increment) $base-increment;
-  }
-  &.size--sm {
-    $font-size: round(0.82 * $base-font-size);
-    font-size: $font-size;
-    line-height: $font-size + 2px;
-    padding: round(0.25 * $base-increment) $base-increment;
-  }
-  &.size--md {
-    $font-size: round(0.85 * $base-font-size);
-    font-size: $font-size;
-    line-height: $font-size + 4px;
-    padding-top: round(0.25 * $base-increment);
-    padding-bottom: round(0.25 * $base-increment);
-  }
-  &.size--lg {
-    $font-size: round(1.1 * $base-font-size);
-    font-size: $font-size;
-    line-height: $font-size + 4px;
-    padding-top: round(0.5 * $base-increment);
-    padding-bottom: round(0.5 * $base-increment);
-  }
-  &.size--xl {
-    $font-size: round(1.3 * $base-font-size);
-    font-size: $font-size;
-    line-height: $font-size + 4px;
-    padding-top: round(1 * $base-increment);
-    padding-bottom: round(1 * $base-increment);
-  }
-
-  &--clickable {
-    cursor: pointer;
+#{$css-scope} {
+  .w-tag {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    border-radius: $border-radius;
+    border: 1px solid rgba(var(--w-contrast-bg-color-rgb), 0.08);
+    background-color: rgba(var(--w-base-bg-color-rgb), 0.85);
+    padding-left: 2 * $base-increment;
+    padding-right: 2 * $base-increment;
+    cursor: default;
     user-select: none;
-    -webkit-tap-highlight-color: transparent;
 
-    .w-tag__closable {
-      margin-left: 3px;
-      margin-right: -3px;
-      padding: 1px;
-      transition: $transition-duration;
+    @include themeable;
+
+    &--dark {color: rgba(var(--w-base-bg-color-rgb), 0.95);}
+    &--outline {background-color: transparent;border-color: currentColor;}
+    &--no-border {border-color: transparent;}
+    &--round {border-radius: 99em;}
+    &--tile {border-radius: initial;}
+    &--shadow {box-shadow: $box-shadow;}
+
+    &.size--xs {
+      $font-size: round(0.7 * $base-font-size);
+      font-size: $font-size;
+      line-height: $font-size + 2px;
+      padding: round(0.25 * $base-increment) $base-increment;
     }
-    &.size--lg .w-tag__closable,
-    &.size--xl .w-tag__closable {
-      margin-right: -2px;
-      padding: 2px;
+    &.size--sm {
+      $font-size: round(0.82 * $base-font-size);
+      font-size: $font-size;
+      line-height: $font-size + 2px;
+      padding: round(0.25 * $base-increment) $base-increment;
+    }
+    &.size--md {
+      $font-size: round(0.85 * $base-font-size);
+      font-size: $font-size;
+      line-height: $font-size + 4px;
+      padding-top: round(0.25 * $base-increment);
+      padding-bottom: round(0.25 * $base-increment);
+    }
+    &.size--lg {
+      $font-size: round(1.1 * $base-font-size);
+      font-size: $font-size;
+      line-height: $font-size + 4px;
+      padding-top: round(0.5 * $base-increment);
+      padding-bottom: round(0.5 * $base-increment);
+    }
+    &.size--xl {
+      $font-size: round(1.3 * $base-font-size);
+      font-size: $font-size;
+      line-height: $font-size + 4px;
+      padding-top: round(1 * $base-increment);
+      padding-bottom: round(1 * $base-increment);
     }
 
-    &:hover {
-      .w-tag__closable {background-color: rgba(var(--w-contrast-bg-color-rgb), 0.1);}
+    &--clickable {
+      cursor: pointer;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+
+      .w-tag__closable {
+        margin-left: 3px;
+        margin-right: -3px;
+        padding: 1px;
+        transition: $transition-duration;
+      }
+      &.size--lg .w-tag__closable,
+      &.size--xl .w-tag__closable {
+        margin-right: -2px;
+        padding: 2px;
+      }
+
+      &:hover {
+        .w-tag__closable {background-color: rgba(var(--w-contrast-bg-color-rgb), 0.1);}
+      }
+
+      // Overlay to mark the focus and active state.
+      &:before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        background-color: transparent;
+        // As this overlay is a smaller rectangle, the radius must be smaller to cover perfectly.
+        border-radius: $border-radius - 1;
+        transition: 0.2s;
+      }
+      &.w-tag--round:before {border-radius: inherit;}
+
+      // Hover state.
+      &:hover:before {background-color: currentColor;opacity: 0.06;}
+      &--dark:hover:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.12);opacity: 1;}
+      &--outline:hover:before,
+      &--text:hover:before {background-color: currentColor;opacity: 0.12;}
+
+      // Focus state.
+      &:focus:before {background-color: currentColor;opacity: 0.2;}
+      &--dark:focus:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.12);}
+      &--outline:focus:before,
+      &--text:focus:before {background-color: currentColor;opacity: 0.12;}
+
+      // Active state.
+      &:active:before {background-color: currentColor;opacity: 0.2;}
+      &--dark:active:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.2);}
+      &--outline:active:before,
+      &--text:active:before {background-color: currentColor;opacity: 0.2;}
     }
-
-    // Overlay to mark the focus and active state.
-    &:before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      opacity: 0;
-      background-color: transparent;
-      // As this overlay is a smaller rectangle, the radius must be smaller to cover perfectly.
-      border-radius: $border-radius - 1;
-      transition: 0.2s;
-    }
-    &.w-tag--round:before {border-radius: inherit;}
-
-    // Hover state.
-    &:hover:before {background-color: currentColor;opacity: 0.06;}
-    &--dark:hover:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.12);opacity: 1;}
-    &--outline:hover:before,
-    &--text:hover:before {background-color: currentColor;opacity: 0.12;}
-
-    // Focus state.
-    &:focus:before {background-color: currentColor;opacity: 0.2;}
-    &--dark:focus:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.12);}
-    &--outline:focus:before,
-    &--text:focus:before {background-color: currentColor;opacity: 0.12;}
-
-    // Active state.
-    &:active:before {background-color: currentColor;opacity: 0.2;}
-    &--dark:active:before {background-color: rgba(var(--w-base-bg-color-rgb), 0.2);}
-    &--outline:active:before,
-    &--text:active:before {background-color: currentColor;opacity: 0.2;}
   }
 }
 </style>

--- a/src/wave-ui/components/w-textarea.vue
+++ b/src/wave-ui/components/w-textarea.vue
@@ -222,176 +222,178 @@ export default {
 <style lang="scss">
 $inactive-color: #777;
 
-.w-textarea {
-  position: relative;
-  display: flex;
-  flex-grow: 1;
-  flex-wrap: wrap;
-  font-size: $base-font-size;
-
-  @include themeable;
-
-  // textarea wrapper.
-  // ------------------------------------------------------
-  &__textarea-wrap {
+#{$css-scope} {
+  .w-textarea {
     position: relative;
-    display: inline-flex;
-    flex: 1 1 auto;
-    min-height: $form-field-height;
-    border-radius: $border-radius;
-    border: $border;
-    transition: border $transition-duration;
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+    font-size: $base-font-size;
 
-    .w-textarea[class^="bdrs"] &, .w-textarea[class*=" bdrs"] & {border-radius: inherit;}
-  }
+    @include themeable;
 
-  &--floating-label &__textarea-wrap {margin-top: 4 * $base-increment;}
+    // textarea wrapper.
+    // ------------------------------------------------------
+    &__textarea-wrap {
+      position: relative;
+      display: inline-flex;
+      flex: 1 1 auto;
+      min-height: $form-field-height;
+      border-radius: $border-radius;
+      border: $border;
+      transition: border $transition-duration;
 
-  &__textarea-wrap--underline {
-    border-bottom-left-radius: initial;
-    border-bottom-right-radius: initial;
-    border-width: 0 0 1px;
-  }
-
-  &__textarea-wrap--tile {border-radius: initial;}
-  &__textarea-wrap--shadow {box-shadow: $box-shadow;}
-
-  &--focused &__textarea-wrap {border-color: currentColor;}
-
-  // Underline.
-  &__textarea-wrap--underline:after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    width: 100%;
-    height: 0;
-    border-bottom: 2px solid currentColor;
-    transition: $transition-duration;
-    transform: scaleX(0);
-    pointer-events: none;
-  }
-
-  &--focused &__textarea-wrap--underline:after {transform: scaleX(1);}
-
-  // Textarea field.
-  // ------------------------------------------------------
-  &__textarea {
-    width: 100%;
-    height: 100%;
-    font: inherit;
-    line-height: $textarea-line-height;
-    color: inherit;
-    background: none;
-    border: none;
-    outline: none;
-    padding: $base-increment (2 * $base-increment);
-    resize: none;
-
-    .w-textarea--resizable & {resize: vertical;}
-
-    .w-textarea--no-padding & {
-      padding-left: 0;
-      padding-right: 0;
+      .w-textarea[class^="bdrs"] &, .w-textarea[class*=" bdrs"] & {border-radius: inherit;}
     }
 
-    .w-textarea--inner-icon-left & {padding-left: 27px;}
-    .w-textarea--inner-icon-right & {padding-right: 27px;}
+    &--floating-label &__textarea-wrap {margin-top: 4 * $base-increment;}
 
-    .w-textarea--disabled & {
-      color: $disabled-color;
-      cursor: not-allowed;
-      -webkit-tap-highlight-color: transparent;
+    &__textarea-wrap--underline {
+      border-bottom-left-radius: initial;
+      border-bottom-right-radius: initial;
+      border-width: 0 0 1px;
     }
-  }
 
-  &--disabled input::placeholder {color: inherit;}
+    &__textarea-wrap--tile {border-radius: initial;}
+    &__textarea-wrap--shadow {box-shadow: $box-shadow;}
 
-  // Icons inside.
-  // ------------------------------------------------------
-  &__icon {position: absolute;margin-top: $base-increment;}
-  &__icon--inner-left {left: 6px;}
-  &__icon--inner-right {right: 6px;}
-  &--no-padding &__icon--inner-left {left: 1px;}
-  &--no-padding &__icon--inner-right {right: 1px;}
+    &--focused &__textarea-wrap {border-color: currentColor;}
 
-  .w-textarea--focused &__icon {color: currentColor;}
-
-  &--disabled &__icon {
-    color: $disabled-color;
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  // Label.
-  // ------------------------------------------------------
-  &__label {
-    transition: color $transition-duration;
-    cursor: pointer;
-    align-self: flex-start;
-    user-select: none;
-
-    &--left {
-      margin-top: $base-increment;
-      margin-right: 2 * $base-increment;
-    }
-    &--right {
-      margin-top: $base-increment;
-      margin-left: 2 * $base-increment;
-    }
-    .w-textarea--disabled & {
-      color: $disabled-color;
-      cursor: not-allowed;
-      -webkit-tap-highlight-color: transparent;
-    }
-    .w-textarea--readonly.w-textarea--empty & {
-      opacity: 0.5;
-      cursor: auto;
-    }
-  }
-
-  &__label--inside {
-    position: absolute;
-    top: $base-increment;
-    left: 0;
-    padding-left: 2 * $base-increment;
-    white-space: nowrap;
-    transform: translateY(0%);
-    pointer-events: none;
-
-    .w-textarea--no-padding & {
+    // Underline.
+    &__textarea-wrap--underline:after {
+      content: '';
+      position: absolute;
+      bottom: -1px;
       left: 0;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    .w-textarea--inner-icon-left & {left: 18px;}
-    .w-textarea--no-padding.w-textarea--inner-icon-left & {left: 26px;}
-
-    .w-textarea--floating-label & {
-      transform-origin: 0 0;
-      transition: $transition-duration ease;
+      width: 100%;
+      height: 0;
+      border-bottom: 2px solid currentColor;
+      transition: $transition-duration;
+      transform: scaleX(0);
+      pointer-events: none;
     }
 
-    // move label with underline style.
-    .w-textarea--focused.w-textarea--floating-label &,
-    .w-textarea--filled.w-textarea--floating-label &,
-    .w-textarea--has-placeholder.w-textarea--floating-label & {
-      transform: translateY(-110%) scale(0.85);
+    &--focused &__textarea-wrap--underline:after {transform: scaleX(1);}
+
+    // Textarea field.
+    // ------------------------------------------------------
+    &__textarea {
+      width: 100%;
+      height: 100%;
+      font: inherit;
+      line-height: $textarea-line-height;
+      color: inherit;
+      background: none;
+      border: none;
+      outline: none;
+      padding: $base-increment (2 * $base-increment);
+      resize: none;
+
+      .w-textarea--resizable & {resize: vertical;}
+
+      .w-textarea--no-padding & {
+        padding-left: 0;
+        padding-right: 0;
+      }
+
+      .w-textarea--inner-icon-left & {padding-left: 27px;}
+      .w-textarea--inner-icon-right & {padding-right: 27px;}
+
+      .w-textarea--disabled & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
     }
-    // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
-    .w-textarea--floating-label .w-textarea__textarea:-webkit-autofill & {
-      transform: translateY(-110%) scale(0.85);
+
+    &--disabled input::placeholder {color: inherit;}
+
+    // Icons inside.
+    // ------------------------------------------------------
+    &__icon {position: absolute;margin-top: $base-increment;}
+    &__icon--inner-left {left: 6px;}
+    &__icon--inner-right {right: 6px;}
+    &--no-padding &__icon--inner-left {left: 1px;}
+    &--no-padding &__icon--inner-right {right: 1px;}
+
+    .w-textarea--focused &__icon {color: currentColor;}
+
+    &--disabled &__icon {
+      color: $disabled-color;
+      cursor: not-allowed;
+      -webkit-tap-highlight-color: transparent;
     }
-    // Move label with outline style or with shadow.
-    .w-textarea--focused.w-textarea--floating-label .w-textarea__textarea-wrap--box &,
-    .w-textarea--filled.w-textarea--floating-label .w-textarea__textarea-wrap--box &,
-    .w-textarea--has-placeholder.w-textarea--floating-label .w-textarea__textarea-wrap--box & {
-      transform: translateY(-130%) scale(0.85);
+
+    // Label.
+    // ------------------------------------------------------
+    &__label {
+      transition: color $transition-duration;
+      cursor: pointer;
+      align-self: flex-start;
+      user-select: none;
+
+      &--left {
+        margin-top: $base-increment;
+        margin-right: 2 * $base-increment;
+      }
+      &--right {
+        margin-top: $base-increment;
+        margin-left: 2 * $base-increment;
+      }
+      .w-textarea--disabled & {
+        color: $disabled-color;
+        cursor: not-allowed;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .w-textarea--readonly.w-textarea--empty & {
+        opacity: 0.5;
+        cursor: auto;
+      }
     }
-    .w-textarea--focused.w-textarea--floating-label.w-textarea--inner-icon-left &,
-    .w-textarea--filled.w-textarea--floating-label.w-textarea--inner-icon-left & {left: 0;}
-    // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
-    .w-textarea--floating-label.w-textarea--inner-icon-left .w-textarea__textarea:-webkit-autofill & {left: 0;}
+
+    &__label--inside {
+      position: absolute;
+      top: $base-increment;
+      left: 0;
+      padding-left: 2 * $base-increment;
+      white-space: nowrap;
+      transform: translateY(0%);
+      pointer-events: none;
+
+      .w-textarea--no-padding & {
+        left: 0;
+        padding-left: 0;
+        padding-right: 0;
+      }
+      .w-textarea--inner-icon-left & {left: 18px;}
+      .w-textarea--no-padding.w-textarea--inner-icon-left & {left: 26px;}
+
+      .w-textarea--floating-label & {
+        transform-origin: 0 0;
+        transition: $transition-duration ease;
+      }
+
+      // move label with underline style.
+      .w-textarea--focused.w-textarea--floating-label &,
+      .w-textarea--filled.w-textarea--floating-label &,
+      .w-textarea--has-placeholder.w-textarea--floating-label & {
+        transform: translateY(-110%) scale(0.85);
+      }
+      // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
+      .w-textarea--floating-label .w-textarea__textarea:-webkit-autofill & {
+        transform: translateY(-110%) scale(0.85);
+      }
+      // Move label with outline style or with shadow.
+      .w-textarea--focused.w-textarea--floating-label .w-textarea__textarea-wrap--box &,
+      .w-textarea--filled.w-textarea--floating-label .w-textarea__textarea-wrap--box &,
+      .w-textarea--has-placeholder.w-textarea--floating-label .w-textarea__textarea-wrap--box & {
+        transform: translateY(-130%) scale(0.85);
+      }
+      .w-textarea--focused.w-textarea--floating-label.w-textarea--inner-icon-left &,
+      .w-textarea--filled.w-textarea--floating-label.w-textarea--inner-icon-left & {left: 0;}
+      // Chrome & Safari - Must remain in a separated rule as Firefox discard the whole rule seeing -webkit-.
+      .w-textarea--floating-label.w-textarea--inner-icon-left .w-textarea__textarea:-webkit-autofill & {left: 0;}
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-timeline.vue
+++ b/src/wave-ui/components/w-timeline.vue
@@ -42,45 +42,47 @@ export default {
 </script>
 
 <style lang="scss">
-.w-timeline {
-  margin-left: $base-increment;
+#{$css-scope} {
+  .w-timeline {
+    margin-left: $base-increment;
 
-  @include themeable;
-}
-
-.w-timeline-item {
-  padding-left: 5 * $base-increment;
-  padding-bottom: 3 * $base-increment;
-  list-style-type: none;
-  position: relative;
-
-  &:last-child {padding-bottom: 0;}
-
-  // Bullet.
-  &__bullet {
-    position: absolute;
-    top: 2px;
-    left: 0;
-    background-color: $timeline-bullet-color;
-    border-radius: 1em;
-    border: 1px solid currentColor;
-    width: $base-font-size;
-    aspect-ratio: 1;
-    min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
-    transform: translateX(-50%);
-    z-index: 1;
+    @include themeable;
   }
-  &__bullet.w-icon {border: none;}
 
-  &:last-child:after {display: none;}
-  // Left border.
-  &:after {
-    content: '';
-    position: absolute;
-    top: 2px;
-    bottom: -2px;
-    left: -1px;
-    border-left: 2px solid $timeline-bg-color;
+  .w-timeline-item {
+    padding-left: 5 * $base-increment;
+    padding-bottom: 3 * $base-increment;
+    list-style-type: none;
+    position: relative;
+
+    &:last-child {padding-bottom: 0;}
+
+    // Bullet.
+    &__bullet {
+      position: absolute;
+      top: 2px;
+      left: 0;
+      background-color: $timeline-bullet-color;
+      border-radius: 1em;
+      border: 1px solid currentColor;
+      width: $base-font-size;
+      aspect-ratio: 1;
+      min-width: 0; // Safari ratio fix (e.g. losing ratio if height is set and side padding are added).
+      transform: translateX(-50%);
+      z-index: 1;
+    }
+    &__bullet.w-icon {border: none;}
+
+    &:last-child:after {display: none;}
+    // Left border.
+    &:after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      bottom: -2px;
+      left: -1px;
+      border-left: 2px solid $timeline-bg-color;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-toolbar.vue
+++ b/src/wave-ui/components/w-toolbar.vue
@@ -64,67 +64,69 @@ export default {
 </script>
 
 <style lang="scss">
-.w-toolbar {
-  position: relative;
-  display: flex;
-  flex: 0 1 auto; // No grow, so it doesn't stretch vertically in flex column.
-  align-items: center;
-  padding: (2 * $base-increment) (3 * $base-increment);
-  background-color: $toolbar-bg-color;
-  z-index: 10;
+#{$css-scope} {
+  .w-toolbar {
+    position: relative;
+    display: flex;
+    flex: 0 1 auto; // No grow, so it doesn't stretch vertically in flex column.
+    align-items: center;
+    padding: (2 * $base-increment) (3 * $base-increment);
+    background-color: $toolbar-bg-color;
+    z-index: 10;
 
-  @include themeable;
+    @include themeable;
 
-  &--absolute, &--fixed {top: 0;left: 0;right: 0;}
-  &--absolute {position: absolute;}
-  &--fixed {position: fixed;}
-  &--absolute.w-toolbar--vertical, &--fixed.w-toolbar--vertical {top: 0;bottom: 0;}
-  &--absolute.w-toolbar--left, &--fixed.w-toolbar--left {left: 0;right: auto;}
-  &--absolute.w-toolbar--right, &--fixed.w-toolbar--right {left: auto;right: 0;}
+    &--absolute, &--fixed {top: 0;left: 0;right: 0;}
+    &--absolute {position: absolute;}
+    &--fixed {position: fixed;}
+    &--absolute.w-toolbar--vertical, &--fixed.w-toolbar--vertical {top: 0;bottom: 0;}
+    &--absolute.w-toolbar--left, &--fixed.w-toolbar--left {left: 0;right: auto;}
+    &--absolute.w-toolbar--right, &--fixed.w-toolbar--right {left: auto;right: 0;}
 
-  // Horizontal.
-  &--top {border-bottom: $border;}
-  &--bottom {
-    bottom: 0;
-    top: auto;
-    border-top: $border;
-  }
+    // Horizontal.
+    &--top {border-bottom: $border;}
+    &--bottom {
+      bottom: 0;
+      top: auto;
+      border-top: $border;
+    }
 
-  // Vertical.
-  &--vertical {
-    padding: (2 * $base-increment);
-    flex-direction: column;
-    flex-shrink: 0;
-  }
+    // Vertical.
+    &--vertical {
+      padding: (2 * $base-increment);
+      flex-direction: column;
+      flex-shrink: 0;
+    }
 
-  &--left {border-right: $border;}
-  &--right {
-    right: 0;
-    left: auto;
-    border-left: $border;
-  }
+    &--left {border-right: $border;}
+    &--right {
+      right: 0;
+      left: auto;
+      border-left: $border;
+    }
 
-  &--no-border, &--shadow {border-width: 0;}
-  &--shadow {box-shadow: $box-shadow;}
+    &--no-border, &--shadow {border-width: 0;}
+    &--shadow {box-shadow: $box-shadow;}
 
-  .w-app > & {z-index: 200;}
+    .w-app > & {z-index: 200;}
 
-  // In w-card.
-  .w-card__title & {
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
-  }
-  .w-card__actions & {
-    border-bottom-left-radius: inherit;
-    border-bottom-right-radius: inherit;
-  }
-  .w-card__content &--left {
-    border-top-left-radius: inherit;
-    border-bottom-left-radius: inherit;
-  }
-  .w-card__content &--right {
-    border-top-right-radius: inherit;
-    border-bottom-right-radius: inherit;
+    // In w-card.
+    .w-card__title & {
+      border-top-left-radius: inherit;
+      border-top-right-radius: inherit;
+    }
+    .w-card__actions & {
+      border-bottom-left-radius: inherit;
+      border-bottom-right-radius: inherit;
+    }
+    .w-card__content &--left {
+      border-top-left-radius: inherit;
+      border-bottom-left-radius: inherit;
+    }
+    .w-card__content &--right {
+      border-top-right-radius: inherit;
+      border-bottom-right-radius: inherit;
+    }
   }
 }
 </style>

--- a/src/wave-ui/components/w-tooltip.vue
+++ b/src/wave-ui/components/w-tooltip.vue
@@ -215,89 +215,90 @@ export default {
 </script>
 
 <style lang="scss">
-.w-tooltip {
-  // Fix Safari where `width: max-content` does not take padding and border into consideration.
-  display: table;
+#{$css-scope} {
+  .w-tooltip {
+    // Fix Safari where `width: max-content` does not take padding and border into consideration.
+    display: table;
 
-  position: absolute;
-  padding: $base-increment round(1.5 * $base-increment);
-  border-radius: $border-radius;
-  border: 1px solid $tooltip-border-color;
-  background-color: $tooltip-bg-color;
-  pointer-events: none;
-  color: $tooltip-color;
-  align-items: center;
-  max-width: 300px;
-  width: max-content; // Not supported in IE11. :/
-  z-index: 100;
+    position: absolute;
+    padding: $base-increment round(1.5 * $base-increment);
+    border-radius: $border-radius;
+    border: 1px solid $tooltip-border-color;
+    background-color: $tooltip-bg-color;
+    pointer-events: none;
+    color: $tooltip-color;
+    align-items: center;
+    max-width: 300px;
+    width: max-content; // Not supported in IE11. :/
+    z-index: 100;
 
-  @include themeable;
+    @include themeable;
 
-  &--fixed {position: fixed;z-index: 1000;}
+    &--fixed {position: fixed;z-index: 1000;}
 
-  &--tile {border-radius: 0;}
-  &--round {
-    border-radius: 99em;
-    padding: $base-increment round(2.5 * $base-increment);
+    &--tile {border-radius: 0;}
+    &--round {
+      border-radius: 99em;
+      padding: $base-increment round(2.5 * $base-increment);
+    }
+    &--shadow {box-shadow: $box-shadow;}
+    &--no-border {border: none;}
+
+    &--top {margin-top: -3 * $base-increment;}
+    &--bottom {margin-top: 3 * $base-increment;}
+    &--left {margin-left: -3 * $base-increment;}
+    &--right {margin-left: 3 * $base-increment;}
+
+    &.size--xs {font-size: 0.75rem;}
+    &.size--sm {font-size: 0.83rem;}
+    &.size--md {font-size: 0.9rem;}
+    &.size--lg {font-size: 1rem;}
+    &.size--xl {font-size: 1.1rem;}
+
+    &--custom-transition {transform: none;}
+
+    // Tooltip without border.
+    &--no-border {
+      @include triangle(var(--w-tooltip-bg-color), '.w-tooltip', 7px, 0);
+    }
+
+    // Tooltip with border.
+    &:not(&--no-border) {
+      @include triangle(var(--w-tooltip-bg-color), '.w-tooltip', 7px);
+    }
   }
-  &--shadow {box-shadow: $box-shadow;}
-  &--no-border {border: none;}
 
-  &--top {margin-top: -3 * $base-increment;}
-  &--bottom {margin-top: 3 * $base-increment;}
-  &--left {margin-left: -3 * $base-increment;}
-  &--right {margin-left: 3 * $base-increment;}
-
-  &.size--xs {font-size: 0.75rem;}
-  &.size--sm {font-size: 0.83rem;}
-  &.size--md {font-size: 0.9rem;}
-  &.size--lg {font-size: 1rem;}
-  &.size--xl {font-size: 1.1rem;}
-
-  &--custom-transition {transform: none;}
-
-  // Tooltip without border.
-  &--no-border {
-    @include triangle(var(--w-tooltip-bg-color), '.w-tooltip', 7px, 0);
+  // Transitions.
+  // --------------------------------------------------------
+  .w-tooltip-slide-fade-up-enter-active, .w-tooltip-slide-fade-up-leave-active,
+  .w-tooltip-slide-fade-down-enter-active, .w-tooltip-slide-fade-down-leave-active,
+  .w-tooltip-slide-fade-left-enter-active, .w-tooltip-slide-fade-left-leave-active,
+  .w-tooltip-slide-fade-right-enter-active, .w-tooltip-slide-fade-right-leave-active {
+    transition: margin $transition-duration ease-in-out, opacity $transition-duration ease-in-out;
   }
 
-  // Tooltip with border.
-  &:not(&--no-border) {
-    @include triangle(var(--w-tooltip-bg-color), '.w-tooltip', 7px);
+  // slide-fade-up.
+  .w-tooltip-slide-fade-up-enter-from, .w-tooltip-slide-fade-up-leave-to {
+    margin-top: -2 * $base-increment;
+    opacity: 0;
+  }
+
+  // slide-fade-down.
+  .w-tooltip-slide-fade-down-enter-from, .w-tooltip-slide-fade-down-leave-to {
+    margin-top: 2 * $base-increment;
+    opacity: 0;
+  }
+
+  // Slide-fade-left.
+  .w-tooltip-slide-fade-left-enter-from, .w-tooltip-slide-fade-left-leave-to {
+    margin-left: -2 * $base-increment;
+    opacity: 0;
+  }
+
+  // Slide-fade-right.
+  .w-tooltip-slide-fade-right-enter-from, .w-tooltip-slide-fade-right-leave-to {
+    margin-left: 2 * $base-increment;
+    opacity: 0;
   }
 }
-
-// Transitions.
-// --------------------------------------------------------
-.w-tooltip-slide-fade-up-enter-active, .w-tooltip-slide-fade-up-leave-active,
-.w-tooltip-slide-fade-down-enter-active, .w-tooltip-slide-fade-down-leave-active,
-.w-tooltip-slide-fade-left-enter-active, .w-tooltip-slide-fade-left-leave-active,
-.w-tooltip-slide-fade-right-enter-active, .w-tooltip-slide-fade-right-leave-active {
-  transition: margin $transition-duration ease-in-out, opacity $transition-duration ease-in-out;
-}
-
-// slide-fade-up.
-.w-tooltip-slide-fade-up-enter-from, .w-tooltip-slide-fade-up-leave-to {
-  margin-top: -2 * $base-increment;
-  opacity: 0;
-}
-
-// slide-fade-down.
-.w-tooltip-slide-fade-down-enter-from, .w-tooltip-slide-fade-down-leave-to {
-  margin-top: 2 * $base-increment;
-  opacity: 0;
-}
-
-// Slide-fade-left.
-.w-tooltip-slide-fade-left-enter-from, .w-tooltip-slide-fade-left-leave-to {
-  margin-left: -2 * $base-increment;
-  opacity: 0;
-}
-
-// Slide-fade-right.
-.w-tooltip-slide-fade-right-enter-from, .w-tooltip-slide-fade-right-leave-to {
-  margin-left: 2 * $base-increment;
-  opacity: 0;
-}
-// --------------------------------------------------------
 </style>

--- a/src/wave-ui/components/w-tree.vue
+++ b/src/wave-ui/components/w-tree.vue
@@ -341,68 +341,70 @@ export default {
 <style lang="scss">
 $expand-icon-size: 20px;
 
-.w-tree {
-  margin: 0;
+#{$css-scope} {
+  .w-tree {
+    margin: 0;
 
-  // Tree items.
-  // ------------------------------------------------------
-  &__item {list-style-type: none;}
-  &__item--branch {}
-  &__item--leaf {margin-left: $base-increment * 5 + 2px;}
-  &--no-expand-button &__item--leaf {margin-left: 0;}
+    // Tree items.
+    // ------------------------------------------------------
+    &__item {list-style-type: none;}
+    &__item--branch {}
+    &__item--leaf {margin-left: $base-increment * 5 + 2px;}
+    &--no-expand-button &__item--leaf {margin-left: 0;}
 
-  // Tree item label.
-  // ------------------------------------------------------
-  &__item-label {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    user-select: none;
+    // Tree item label.
+    // ------------------------------------------------------
+    &__item-label {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      user-select: none;
 
-    &:before {
-      content: '';
-      position: absolute;
-      top: -1px;
-      bottom: -1px;
-      left: - $base-increment + 2px;
-      right: - $base-increment - 2px;
-      border-radius: $border-radius;
+      &:before {
+        content: '';
+        position: absolute;
+        top: -1px;
+        bottom: -1px;
+        left: - $base-increment + 2px;
+        right: - $base-increment - 2px;
+        border-radius: $border-radius;
+      }
+      &:hover:before {background-color: $primary;opacity: 0.1;}
+      &:focus-visible:before {background-color: $primary;opacity: 0.15;}
     }
-    &:hover:before {background-color: $primary;opacity: 0.1;}
-    &:focus-visible:before {background-color: $primary;opacity: 0.15;}
-  }
-  &.w-tree--selectable &__item-label {cursor: pointer;}
-  &.w-tree--selectable &__item--disabled &__item-label {cursor: auto;}
-  &__item--leaf &__item-label:before {
-    left: - $base-increment;
-    right: - $base-increment;
-  }
-  &__item--selected > &__item-label:before {
-    background-color: $primary;
-    opacity: 0.25;
-  }
-  &__item--disabled &__item-label {opacity: 0.5;}
-  &__item--disabled &__item-label:before {display: none;}
+    &.w-tree--selectable &__item-label {cursor: pointer;}
+    &.w-tree--selectable &__item--disabled &__item-label {cursor: auto;}
+    &__item--leaf &__item-label:before {
+      left: - $base-increment;
+      right: - $base-increment;
+    }
+    &__item--selected > &__item-label:before {
+      background-color: $primary;
+      opacity: 0.25;
+    }
+    &__item--disabled &__item-label {opacity: 0.5;}
+    &__item--disabled &__item-label:before {display: none;}
 
-  &__item-expand {margin-right: 2px;}
+    &__item-expand {margin-right: 2px;}
 
-  &__item--branch > &__item-label {cursor: pointer;}
-  &__item--disabled > &__item-label {
-    color: $disabled-color;
-    cursor: not-allowed;
-    -webkit-tap-highlight-color: transparent;
+    &__item--branch > &__item-label {cursor: pointer;}
+    &__item--disabled > &__item-label {
+      color: $disabled-color;
+      cursor: not-allowed;
+      -webkit-tap-highlight-color: transparent;
+    }
+    &__item--unexpandable > &__item-label {
+      margin-left: $expand-icon-size + 2px;
+      cursor: auto;
+    }
+    &--disabled &__item-label {cursor: auto;}
+    &--disabled &__item--branch > &__item-label {opacity: 0.5;}
+
+    &__item-icon {margin-right: $base-increment;}
+
+    // Recursive children.
+    // ------------------------------------------------------
+    .w-tree {margin-left: $base-increment * 5;}
   }
-  &__item--unexpandable > &__item-label {
-    margin-left: $expand-icon-size + 2px;
-    cursor: auto;
-  }
-  &--disabled &__item-label {cursor: auto;}
-  &--disabled &__item--branch > &__item-label {opacity: 0.5;}
-
-  &__item-icon {margin-right: $base-increment;}
-
-  // Recursive children.
-  // ------------------------------------------------------
-  .w-tree {margin-left: $base-increment * 5;}
 }
 </style>


### PR DESCRIPTION
Currently we have the lovely `css-scope` property which we can override as documented [here](https://antoniandre.github.io/wave-ui/customization#give-wave-ui-css-more-priority).

If this is set with a 2 level, or deeper, specificity such as `$css-scope:'.w-app .app'` then we get a good chunk of the CSS (currently everything in the scss files) prefixed with this scope. Which is fantastic.

However, there are some instances where because of this it makes certain styles MORE specific than the styles for the components. One example is for the `w-table` component, with the pagination specifically, the buttons get the `size--lg` class added to them.

The resulting class with scope for `size--lg` ends up being `.w-app .app .size--lg` which is MORE specific than the specificity from the `w-table` component for those buttons and their font size which is `.w-table__pagination .w-pagination__page`.

This commit adds the `css-scope` prefix/wrapper to all the component styles which fixes this issue and keeps the stylings far more consistent across the board.

If you use the `hide whitespace` option when viewing the `Files changed` tab you can see that there really aren't that many changes overall. A lot of indentation.

---

To be fair my use case with Wave may be a little unconventional, where I'm slowly migrating a legacy PHP codebase into using Vue components. Because the `w-app` gets added to the `<body>` tag I've had to change the `css-scope` so that none of the styles/classes affect the original pages. This prevents any leaking which is amazing! But then I have this issue of specificity on some of the components.