### PR TITLE
[w-table] Pagination issue

### DIFF
--- a/src/wave-ui/components/w-table.vue
+++ b/src/wave-ui/components/w-table.vue
@@ -615,11 +615,11 @@ export default {
         this.paginationConfig.itemsPerPage = itemsPerPage
         itemsPerPage = itemsPerPage || this.paginationConfig.total // If `0`, take all the results.
         this.paginationConfig.page = page || this.paginationConfig.page || 1
-        page = this.paginationConfig.page // Shorthand var for next lines.
-        total = this.paginationConfig.total // Shorthand var for next lines.
+        let p = this.paginationConfig.page // Shorthand var for next lines.
+        let t = this.paginationConfig.total // Shorthand var for next lines.
         this.paginationConfig.start = 1
-        this.paginationConfig.end = total >= (itemsPerPage * page) ? (itemsPerPage * page) : (total % (itemsPerPage * page))
-        this.paginationConfig.pagesCount = Math.ceil(total / itemsPerPage)
+        this.paginationConfig.end = t>= (itemsPerPage * p) ? (itemsPerPage * p) : (t % (itemsPerPage * p))
+        this.paginationConfig.pagesCount = Math.ceil(t/ itemsPerPage)
       }
       if (page) this.goToPage(page)
     },


### PR DESCRIPTION
Currently with the `w-table` pagination if you adjust the `pagination.page` value a watcher is fired off to re-calculate the pagination values so they're adjusted correctly.

The method that gets called to update everything is `updatePaginationConfig`, which you can pass an object of data to for internal uses adjusting the page and total it would seem?

There's a section of this code that assigns some variables for shorthand use with some math, but they override the parameter variables. So then this logic `if (page) this.goToPage(page)` is always true because we've overridden the `page` variable, so it will attempt to re-load the page again. This causes my setup to loop infinitely, unless it hits 0. Perhaps I'm using this wrong though?

Currently the way I'm attempting to use it like this:
```typescript
const tablePagination = computed(() => ({
	itemsPerPage: report.value.pagination.rowsPerPage,
	start       : report.value.pagination.currentPage * report.value.pagination.rowsPerPage,
	end         : (report.value.pagination.currentPage * report.value.pagination.rowsPerPage) + report.value.pagination.rowsPerPage,
	// I add one here because the math I had was a 0 based pagination on the server.
	page        : report.value.pagination.currentPage + 1,
	total       : report.value.totalResults,
}));
```

And for fetching I'm using:
```
// Again it's -1 because my stuff is 0 indexed
:fetch="({ page }) => gotoPage(page - 1)"
```

This causes some really weird behavior unless we use the fix I have in this PR. Again, perhaps I'm doing something wonky here. I'm fine if you toss this out. I can always use the slot for what I need.