### PR TITLE
[w-overlay] Prevent Body Scrolling

### DIFF
--- a/src/wave-ui/components/w-overlay.vue
+++ b/src/wave-ui/components/w-overlay.vue
@@ -84,6 +84,7 @@ export default {
       this.$emit('update:modelValue', false)
       this.$emit('input', false)
       if (!this.modelValue) this.$emit('close') // Only emit once.
+      document.body.classList.remove('w-no-scroll')
     }
   },
 
@@ -93,13 +94,22 @@ export default {
 
   watch: {
     modelValue (bool) {
-      if (bool) this.showOverlay = true
+      if (bool) {
+        this.showOverlay = true
+        document.body.classList.add('w-no-scroll')
+      } else {
+        document.body.classList.remove('w-no-scroll')
+      }
     }
   }
 }
 </script>
 
 <style lang="scss">
+.w-no-scroll {
+  overflow: hidden;
+}
+
 .w-overlay {
   z-index: 500;
   position: fixed;


### PR DESCRIPTION
Currently if we trigger an overlay or dialog the body behind it still scrolls. This can cause issues for various types of situations.

It's something Bootstrap back in the day implemented, removed, and then added back: https://github.com/twbs/bootstrap/pull/6342 under `Modals` at the end. ` Prevent <body> scrollbar and shifting content with overflow: hidden;.`

Potentially this could also be put behind a prop if it's not behavior that everyone wants.

There's more people discussing how you could potentially implement this [here](https://stackoverflow.com/questions/9538868/prevent-body-from-scrolling-when-a-modal-is-opened)