### PR TITLE
[w-switch] Better Centering

### DIFF
--- a/src/wave-ui/components/w-switch.vue
+++ b/src/wave-ui/components/w-switch.vue
@@ -231,7 +231,6 @@ $outline-width: 2px;
     content: '';
     position: absolute;
     left: 0;
-    top: 0;
     width: $small-form-el-size;
     height: $small-form-el-size;
     background-color: $switch-thumb-color;


### PR DESCRIPTION
I had noticed that for me when viewing the `w-thumb` that it never quite looked centered. I was just playing around with the CSS a bit and noticed that removing this `top: 0` seems to make it better centered for me on linux with both Chrome and Firefox.

Firefox Before:
![image](https://github.com/antoniandre/wave-ui/assets/37845846/472f3dd6-ed18-4f6d-9b51-e9c929007f8d)

Firefox After:
![image](https://github.com/antoniandre/wave-ui/assets/37845846/366c37d0-fb34-423a-a73b-ad1452523bb2)

I usually have my browser zoomed in at a `125%` rate so maybe that's why it's off looking sometimes. But I tried zooming in and out with the `top: 0` removed and I think it looks more centered for me overall. Curious how it looks for you @antoniandre 
