### PR TITLE
[w-autocomplete] Using strings as the value

### DIFF
--- a/src/wave-ui/components/w-autocomplete.vue
+++ b/src/wave-ui/components/w-autocomplete.vue
@@ -301,7 +301,7 @@ export default {
     if (this.modelValue) {
       const arrayOfValues = Array.isArray(this.modelValue) ? this.modelValue : [this.modelValue]
       arrayOfValues.forEach(value => {
-        this.selection.push(this.optimizedItemsForSearch.find(item => item[this.itemValueKey] === +value))
+        this.selection.push(this.optimizedItemsForSearch.find(item => item[this.itemValueKey] === value))
       })
     }
   },
@@ -316,7 +316,7 @@ export default {
       if (value) {
         const arrayOfValues = Array.isArray(value) ? value : [value]
         arrayOfValues.forEach(value => {
-          this.selection.push(this.optimizedItemsForSearch.find(item => item[this.itemValueKey] === +value))
+          this.selection.push(this.optimizedItemsForSearch.find(item => item[this.itemValueKey] === value))
         })
       }
     }


### PR DESCRIPTION
There appears to be a bug with w-autocomplete that currently restricts it to working with numbers as the item value. The modelValue is typed as `String, Number, Array` so I'm assuming it was intended to work with strings too. The modelValue values were being converted to a number during the item list comparison, which meant it would never find the string values due to the strict comparison.