### PR TITLE
Update w-select types

### DIFF
--- a/src/types/components/WSelect.ts
+++ b/src/types/components/WSelect.ts
@@ -39,10 +39,10 @@ export interface WSelectDropdownItem {
   /**
    * The *default* key to access the vlue of the item.
    * This can be overriden using the `item-value-key` property.
-   * @property {string} value
+   * @property {string|number|boolean} value
    * @see https://antoniandre.github.io/wave-ui/w-select#item-value-key-prop
    */
-  value?: string
+  value?: string|number|boolean
 
   /**
    * Whether or not this list item is disabled.


### PR DESCRIPTION
Update the w-select types so that for each item that gets passed, the `value` can be a `number` or `boolean` and not just limited to strings. As it functions correctly with both of those types as well.