### PR TITLE
Resolve `Could not find a declaration file for module 'wave-ui'` in IDE.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,14 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/wave-ui.es.js",
-      "require": "./dist/wave-ui.umd.js"
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/wave-ui.es.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default":"./dist/wave-ui.umd.js"
+      }
     },
     "./package.json": "./package.json",
     "./dist/*": "./dist/*",


### PR DESCRIPTION
Commit 294258c reverted commit e98c798 of PR#161 -- this PR restores things.

For background, see [Exports Imports and Self-Referencing](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package.json-exports-imports-and-self-referencing) in the Typescript 4.7 Release Notes.

The full warning includes: "There are types at X, but this result could not be resolved when respecting package.json "exports". The X library may need to update its package.json or typings."